### PR TITLE
refactor(core): simplify route layout building by introducing `RouteLayout.buildRoot` and `buildPath` methods.

### DIFF
--- a/packages/zenrouter/doc/paradigms/coordinator/example/lib/routes/app_route.dart
+++ b/packages/zenrouter/doc/paradigms/coordinator/example/lib/routes/app_route.dart
@@ -15,12 +15,7 @@ class HomeLayout extends AppRoute with RouteLayout<AppRoute> {
     final path = resolvePath(coordinator);
 
     return Scaffold(
-      body: RouteLayout.buildPrimitivePath<AppRoute>(
-        IndexedStackPath,
-        coordinator,
-        path,
-        this,
-      ),
+      body: buildPath(coordinator),
       bottomNavigationBar: BottomNavigationBar(
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
@@ -57,14 +52,7 @@ class FeedLayout extends AppRoute with RouteLayout<AppRoute> {
 
   @override
   Widget build(AppCoordinator coordinator, BuildContext context) {
-    final path = resolvePath(coordinator);
-
-    return RouteLayout.buildPrimitivePath<AppRoute>(
-      NavigationPath,
-      coordinator,
-      path,
-      this,
-    );
+    return buildPath(coordinator);
   }
 }
 
@@ -75,18 +63,6 @@ class ProfileLayout extends AppRoute with RouteLayout<AppRoute> {
 
   @override
   Type? get layout => HomeLayout;
-
-  @override
-  Widget build(AppCoordinator coordinator, BuildContext context) {
-    final path = resolvePath(coordinator);
-
-    return RouteLayout.buildPrimitivePath<AppRoute>(
-      NavigationPath,
-      coordinator,
-      path,
-      this,
-    );
-  }
 }
 
 class PostList extends AppRoute {

--- a/packages/zenrouter/example/lib/custom_layout/main.dart
+++ b/packages/zenrouter/example/lib/custom_layout/main.dart
@@ -35,14 +35,7 @@ class CustomLayout extends AppRoute with RouteLayout<AppRoute> {
       body: switch (size.width) {
         < 600 => Column(
           children: [
-            Expanded(
-              child: RouteLayout.buildPrimitivePath(
-                IndexedStackPath,
-                coordinator,
-                path,
-                this,
-              ),
-            ),
+            Expanded(child: buildPath(coordinator)),
             Container(
               height: 60,
               color: Colors.yellow,

--- a/packages/zenrouter/example/lib/main_coordinator.dart
+++ b/packages/zenrouter/example/lib/main_coordinator.dart
@@ -51,12 +51,7 @@ class HomeLayout extends AppRoute with RouteLayout<AppRoute>, RouteTransition {
   Widget build(AppCoordinator coordinator, BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Home'), backgroundColor: Colors.blue),
-      body: RouteLayout.buildPrimitivePath(
-        NavigationPath,
-        coordinator,
-        coordinator.homeStack,
-        this,
-      ),
+      body: buildPath(coordinator),
     );
   }
 
@@ -89,14 +84,7 @@ class TabBarLayout extends AppRoute with RouteLayout<AppRoute> {
       body: Column(
         children: [
           // Tab content (IndexedStack is built by RouteLayout)
-          Expanded(
-            child: RouteLayout.buildPrimitivePath(
-              IndexedStackPath,
-              coordinator,
-              path,
-              this,
-            ),
-          ),
+          Expanded(child: buildPath(coordinator)),
           // Tab bar
           Container(
             color: Colors.grey[200],
@@ -146,12 +134,7 @@ class SettingsLayout extends AppRoute with RouteLayout<AppRoute> {
         leading: BackButton(onPressed: () => coordinator.tryPop()),
         title: const Text('Settings'),
       ),
-      body: RouteLayout.buildPrimitivePath(
-        NavigationPath,
-        coordinator,
-        coordinator.settingsStack,
-        this,
-      ),
+      body: buildPath(coordinator),
     );
   }
 }

--- a/packages/zenrouter/lib/src/coordinator.dart
+++ b/packages/zenrouter/lib/src/coordinator.dart
@@ -87,6 +87,7 @@ abstract class Coordinator<T extends RouteUnique> extends Equatable
     defineLayout();
   }
 
+  // coverage:ignore-start
   @override
   void dispose() {
     super.dispose();
@@ -94,6 +95,7 @@ abstract class Coordinator<T extends RouteUnique> extends Equatable
       path.removeListener(notifyListeners);
     }
   }
+  // coverage:ignore-end
 
   /// The root (primary) navigation path.
   ///
@@ -448,8 +450,7 @@ abstract class Coordinator<T extends RouteUnique> extends Equatable
   /// Builds the root widget (the primary navigator).
   ///
   /// Override to customize the root navigation structure.
-  Widget layoutBuilder(BuildContext context) =>
-      RouteLayout.buildPrimitivePath(NavigationPath, this, root, null);
+  Widget layoutBuilder(BuildContext context) => RouteLayout.buildRoot(this);
 
   /// Attempts to pop the nearest dynamic path.
   /// The [RouteGuard] logic is handled here.

--- a/packages/zenrouter/lib/src/diff.dart
+++ b/packages/zenrouter/lib/src/diff.dart
@@ -147,8 +147,10 @@ List<DiffOp<T>> myersDiff<T>(
     }
   }
 
+  // coverage:ignore-start
   // Should never reach here, but return empty list as fallback
   return [];
+  // coverage:ignore-end
 }
 
 /// Backtrack through the trace to construct the edit script.
@@ -185,10 +187,14 @@ List<DiffOp<T>> _backtrack<T>(
 
     final kMinusOne = (kMinusOneIndex >= 0 && kMinusOneIndex < vSize)
         ? v[kMinusOneIndex]
+        // coverage:ignore-start
         : -1;
+    // coverage:ignore-end
     final kPlusOne = (kPlusOneIndex >= 0 && kPlusOneIndex < vSize)
         ? v[kPlusOneIndex]
+        // coverage:ignore-start
         : -1;
+    // coverage:ignore-end
 
     if (k == -depth || (k != depth && kMinusOne < kPlusOne)) {
       prevK = k + 1;

--- a/packages/zenrouter/lib/src/mixin.dart
+++ b/packages/zenrouter/lib/src/mixin.dart
@@ -152,13 +152,21 @@ mixin RouteLayout<T extends RouteUnique> on RouteUnique {
   }
   // coverage:ignore-end
 
-  static Widget buildRoot(Coordinator coordinator) =>
-      _layoutBuilderTable[coordinator.root.pathKey]!(
-        coordinator,
-        coordinator.root,
-        null,
-      );
+  static Widget buildRoot(Coordinator coordinator) {
+    final rootPathKey = coordinator.root.pathKey;
 
+    if (!_layoutBuilderTable.containsKey(rootPathKey)) {
+      throw UnimplementedError(
+        'You are not provide layout builder for [${rootPathKey.path}] yet. If you extends [StackPath] class you must register it by [RouteLayout.definePath] to use the [RouteLayout.buildRoot]',
+      );
+    }
+
+    return _layoutBuilderTable[rootPathKey]!(
+      coordinator,
+      coordinator.root,
+      null,
+    );
+  }
   /// Build the layout for this route.
   Widget buildPath(Coordinator coordinator) {
     final path = resolvePath(coordinator);

--- a/packages/zenrouter/lib/src/mixin.dart
+++ b/packages/zenrouter/lib/src/mixin.dart
@@ -126,7 +126,7 @@ mixin RouteLayout<T extends RouteUnique> on RouteUnique {
 
   // coverage:ignore-start
   @Deprecated(
-    'Do not manage [layoutBuilderTable] manually. Instead, use [RouteLayout.buildPath] to access it and [defineLayout] to register new builders.',
+    'Do not manage [layoutBuilderTable] manually. Instead, use [RouteLayout.buildPath] to access it and [definePath] to register new builders.',
   )
   static Map<PathKey, RouteLayoutBuilder> get layoutBuilderTable =>
       _layoutBuilderTable;

--- a/packages/zenrouter/lib/src/mixin.dart
+++ b/packages/zenrouter/lib/src/mixin.dart
@@ -167,6 +167,7 @@ mixin RouteLayout<T extends RouteUnique> on RouteUnique {
       null,
     );
   }
+
   /// Build the layout for this route.
   Widget buildPath(Coordinator coordinator) {
     final path = resolvePath(coordinator);

--- a/packages/zenrouter/lib/src/path.dart
+++ b/packages/zenrouter/lib/src/path.dart
@@ -190,9 +190,10 @@ class NavigationPath<T extends RouteTarget> extends StackPath<T>
     List<T>? stack,
   }) => NavigationPath._(label, stack ?? [], coordinator);
 
-  /// The key used to identify this type in [RouteLayout.layoutBuilderTable].
+  /// The key used to identify this type in [RouteLayout.definePath].
   static const key = PathKey('NavigationPath');
 
+  /// NavigationPath key. This is used to identify this type in [RouteLayout.definePath].
   @override
   PathKey get pathKey => key;
 
@@ -274,9 +275,10 @@ class IndexedStackPath<T extends RouteTarget> extends StackPath<T> {
     required String label,
   }) => IndexedStackPath._(stack, debugLabel: label, coordinator: coordinator);
 
-  /// The key used to identify this type in [RouteLayout.layoutBuilderTable].
+  /// The key used to identify this type in [RouteLayout.definePath].
   static const key = PathKey('IndexedStackPath');
 
+  /// IndexedStackPath key. This is used to identify this type in [RouteLayout.definePath].
   @override
   PathKey get pathKey => key;
 

--- a/packages/zenrouter/lib/src/path.dart
+++ b/packages/zenrouter/lib/src/path.dart
@@ -11,6 +11,9 @@ part 'mixin.dart';
 part 'stack.dart';
 part 'transition.dart';
 
+/// Extension type for path keys.
+extension type const PathKey(String path) {}
+
 /// Mixin for stack paths that support mutable operations (push/pop).
 ///
 /// This provides standard implementations for [push], [pushOrMoveToTop], and [pop].
@@ -117,6 +120,10 @@ abstract class StackPath<T extends RouteTarget> with ChangeNotifier {
   /// The currently active route in this stack.
   T? get activeRoute;
 
+  /// The key of this path
+  ///
+  PathKey get pathKey;
+
   /// The current navigation stack as an unmodifiable list.
   ///
   /// The first element is the bottom of the stack (first route),
@@ -182,6 +189,12 @@ class NavigationPath<T extends RouteTarget> extends StackPath<T>
     required String label,
     List<T>? stack,
   }) => NavigationPath._(label, stack ?? [], coordinator);
+
+  /// The key used to identify this type in [RouteLayout.layoutBuilderTable].
+  static const key = PathKey('NavigationPath');
+
+  @override
+  PathKey get pathKey => key;
 
   /// Removes a specific route from the stack (at any position).
   ///
@@ -260,6 +273,12 @@ class IndexedStackPath<T extends RouteTarget> extends StackPath<T> {
     required Coordinator coordinator,
     required String label,
   }) => IndexedStackPath._(stack, debugLabel: label, coordinator: coordinator);
+
+  /// The key used to identify this type in [RouteLayout.layoutBuilderTable].
+  static const key = PathKey('IndexedStackPath');
+
+  @override
+  PathKey get pathKey => key;
 
   int _activeIndex = 0;
 

--- a/packages/zenrouter/test/full_flow_widget_test.dart
+++ b/packages/zenrouter/test/full_flow_widget_test.dart
@@ -242,14 +242,7 @@ class ShellRoute extends AppRoute with RouteLayout<AppRoute> {
       body: Column(
         children: [
           const Text('Shell Container'),
-          Expanded(
-            child: RouteLayout.buildPrimitivePath(
-              NavigationPath,
-              coordinator,
-              coordinator.shellStack,
-              this,
-            ),
-          ),
+          Expanded(child: buildPath(coordinator)),
         ],
       ),
     );

--- a/packages/zenrouter_file_generator/example/lib/routes/(auth)/_layout.dart
+++ b/packages/zenrouter_file_generator/example/lib/routes/(auth)/_layout.dart
@@ -66,12 +66,7 @@ class AuthLayout extends _$AuthLayout {
                     borderRadius: const BorderRadius.vertical(
                       top: Radius.circular(32),
                     ),
-                    child: RouteLayout.buildPrimitivePath(
-                      NavigationPath,
-                      coordinator,
-                      resolvePath(coordinator),
-                      this,
-                    ),
+                    child: buildPath(coordinator),
                   ),
                 ),
               ),

--- a/packages/zenrouter_file_generator/example/lib/routes/tabs/_layout.dart
+++ b/packages/zenrouter_file_generator/example/lib/routes/tabs/_layout.dart
@@ -19,12 +19,7 @@ class TabsLayout extends _$TabsLayout {
     final path = resolvePath(coordinator);
 
     return Scaffold(
-      body: RouteLayout.buildPrimitivePath(
-        IndexedStackPath,
-        coordinator,
-        path,
-        this,
-      ),
+      body: buildPath(coordinator),
       // User has full control over the navigation UI
       bottomNavigationBar: ListenableBuilder(
         listenable: path,


### PR DESCRIPTION
Resolved #32.
This pull request refactors the way route layouts are constructed and registered in the ZenRouter package, moving from string-based layout keys to a new strongly-typed `PathKey` system. It also introduces a new `buildPath` method for building route layouts, deprecates the old `buildPrimitivePath` approach, and updates all usages throughout the codebase and documentation. Additionally, it improves error handling, test coverage, and internal consistency in stack path handling.

**Route layout construction and registration overhaul:**

- Introduced a new `PathKey` extension type for identifying layout builders, replacing string-based keys throughout the codebase. (`[[1]](diffhunk://#diff-c9fd690755923006b333de0eca3cc5955b25c397df0deca63263923e1cafc648R14-R16)`, `[[2]](diffhunk://#diff-c9fd690755923006b333de0eca3cc5955b25c397df0deca63263923e1cafc648R193-R198)`, `[[3]](diffhunk://#diff-c9fd690755923006b333de0eca3cc5955b25c397df0deca63263923e1cafc648R277-R282)`, `[[4]](diffhunk://#diff-d6f7cb9d1998c2fce82bef5ecbda9706d456e9ff4f6a6e33995552429eca2349L86-R89)`, `[[5]](diffhunk://#diff-d6f7cb9d1998c2fce82bef5ecbda9706d456e9ff4f6a6e33995552429eca2349L127-R179)`)
- Added the `buildPath` method to `RouteLayout`, which uses `PathKey` for layout resolution, and deprecated `buildPrimitivePath`. All usages in examples and documentation are updated to use `buildPath`. (`[[1]](diffhunk://#diff-d6f7cb9d1998c2fce82bef5ecbda9706d456e9ff4f6a6e33995552429eca2349L127-R179)`, `[[2]](diffhunk://#diff-d6f7cb9d1998c2fce82bef5ecbda9706d456e9ff4f6a6e33995552429eca2349L170-R195)`, [[3]](diffhunk://#diff-d731a23adc486b58026b7d83b37f53efc851596f58c6da3c5b8fff2e2d786d1eL18-R18) [[4]](diffhunk://#diff-d731a23adc486b58026b7d83b37f53efc851596f58c6da3c5b8fff2e2d786d1eL60-R55) [[5]](diffhunk://#diff-d731a23adc486b58026b7d83b37f53efc851596f58c6da3c5b8fff2e2d786d1eL78-L89) [[6]](diffhunk://#diff-4d243dc791ff39b6f4851358850fef6cd3c69e8429c359dd05098a933b91bd89L38-R38) [[7]](diffhunk://#diff-90a634835fde21a34c6d78ad18ad9210a3a0b557d05e991b95c5c83c58fe0a2fL54-R54) [[8]](diffhunk://#diff-90a634835fde21a34c6d78ad18ad9210a3a0b557d05e991b95c5c83c58fe0a2fL92-R87) [[9]](diffhunk://#diff-90a634835fde21a34c6d78ad18ad9210a3a0b557d05e991b95c5c83c58fe0a2fL149-R137)
- Updated the registration method for custom layouts: `definePrimitivePath` is replaced by `definePath`, which now takes a `PathKey`. (`[packages/zenrouter/lib/src/mixin.dartL127-R179](diffhunk://#diff-d6f7cb9d1998c2fce82bef5ecbda9706d456e9ff4f6a6e33995552429eca2349L127-R179)`)
- Deprecated legacy static layout keys (`navigationPath`, `indexedStackPath`) in favor of the new strongly-typed static keys (`NavigationPath.key`, `IndexedStackPath.key`). (`[packages/zenrouter/lib/src/mixin.dartR67-R71](diffhunk://#diff-d6f7cb9d1998c2fce82bef5ecbda9706d456e9ff4f6a6e33995552429eca2349R67-R71)`)

**Error handling and test improvements:**

- Improved error messages for missing layout builders to reference the new registration method (`definePath`) and updated related tests accordingly. (`[[1]](diffhunk://#diff-7003dde9d6acc990a37ef8dafa5b52dd499c43f58e0cb9983edd3f8edd70d93dL42-R56)`, `[[2]](diffhunk://#diff-7003dde9d6acc990a37ef8dafa5b52dd499c43f58e0cb9983edd3f8edd70d93dL327-R365)`, `[[3]](diffhunk://#diff-7003dde9d6acc990a37ef8dafa5b52dd499c43f58e0cb9983edd3f8edd70d93dL357-R385)`)
- Added new test routes and coordinators to ensure correct error handling and path key usage for both registered and unregistered layouts. (`[[1]](diffhunk://#diff-7003dde9d6acc990a37ef8dafa5b52dd499c43f58e0cb9983edd3f8edd70d93dR113-R152)`, `[[2]](diffhunk://#diff-7003dde9d6acc990a37ef8dafa5b52dd499c43f58e0cb9983edd3f8edd70d93dR185-R213)`)

**Internal consistency and minor improvements:**

- Added coverage ignore comments for code paths that should never be reached or are not relevant for test coverage. (`[[1]](diffhunk://#diff-eda5b4a72def65ccb917c12d0223f5184a1960f478dd9495855bf880695cfdbaR90-R98)`, `[[2]](diffhunk://#diff-094b24b3dbefba09c540da71dc3551b94417da364a9a24ce4628a5f347ae530bR150-R153)`, `[[3]](diffhunk://#diff-094b24b3dbefba09c540da71dc3551b94417da364a9a24ce4628a5f347ae530bR190-R197)`)
- Updated coordinator and stack path classes to use the new `PathKey` system and improved their internal stack management for consistency. (`[[1]](diffhunk://#diff-c9fd690755923006b333de0eca3cc5955b25c397df0deca63263923e1cafc648R123-R126)`, `[[2]](diffhunk://#diff-7003dde9d6acc990a37ef8dafa5b52dd499c43f58e0cb9983edd3f8edd70d93dR185-R213)`)
- Added a new `buildRoot` method to `RouteLayout` for constructing the root widget using the new system. (`[[1]](diffhunk://#diff-eda5b4a72def65ccb917c12d0223f5184a1960f478dd9495855bf880695cfdbaL451-R453)`, `[[2]](diffhunk://#diff-d6f7cb9d1998c2fce82bef5ecbda9706d456e9ff4f6a6e33995552429eca2349L127-R179)`) 