### PR TITLE
refactor(core): Decoupling `StackPath` with built-in feature

### DIFF
--- a/packages/zenrouter/lib/src/coordinator/base.dart
+++ b/packages/zenrouter/lib/src/coordinator/base.dart
@@ -477,9 +477,9 @@ abstract class Coordinator<T extends RouteUnique> extends Equatable
     var routeIndex = routePath.stack.indexOf(route);
 
     void discardRouteIfNeeded(T existingRoute) {
+      // Maximum reuse existing route
       if (existingRoute.hashCode != route.hashCode) {
-        route.onDidPop(null, this);
-        route.completeOnResult(null, this, true);
+        route.onDiscard();
       }
     }
 

--- a/packages/zenrouter/lib/src/coordinator/base.dart
+++ b/packages/zenrouter/lib/src/coordinator/base.dart
@@ -2,15 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:zenrouter/src/internal/equatable.dart';
-import 'package:zenrouter/src/internal/type.dart';
-import 'package:zenrouter/src/mixin/deeplink.dart';
-import 'package:zenrouter/src/mixin/layout.dart';
-import 'package:zenrouter/src/mixin/query_parameters.dart';
-import 'package:zenrouter/src/mixin/redirect.dart';
-import 'package:zenrouter/src/mixin/restoration.dart';
-import 'package:zenrouter/src/mixin/unique.dart';
-import 'package:zenrouter/src/path/base.dart';
-import 'router.dart';
+import 'package:zenrouter/zenrouter.dart';
 
 /// Strategy for resolving parent layouts during navigation.
 enum _ResolveLayoutStrategy {

--- a/packages/zenrouter/lib/src/coordinator/restoration.dart
+++ b/packages/zenrouter/lib/src/coordinator/restoration.dart
@@ -258,10 +258,12 @@ class _CoordinatorRestorableState extends State<CoordinatorRestorable>
   void didUpdateWidget(covariant CoordinatorRestorable oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.coordinator != oldWidget.coordinator) {
+      // coverage:ignore-start
       oldWidget.coordinator.removeListener(_saveCoordinator);
       widget.coordinator.addListener(_saveCoordinator);
       oldWidget.coordinator.removeListener(_saveActiveRoute);
       widget.coordinator.addListener(_saveActiveRoute);
+      // coverage:ignore-end
     }
   }
 

--- a/packages/zenrouter/lib/src/internal/diff.dart
+++ b/packages/zenrouter/lib/src/internal/diff.dart
@@ -1,4 +1,4 @@
-import 'package:zenrouter/src/path/base.dart';
+import 'package:zenrouter/zenrouter.dart';
 
 /// Represents a diff operation between two lists.
 sealed class DiffOp<T> {

--- a/packages/zenrouter/lib/src/mixin/guard.dart
+++ b/packages/zenrouter/lib/src/mixin/guard.dart
@@ -1,4 +1,6 @@
-part of '../path/base.dart';
+import 'dart:async';
+
+import 'package:zenrouter/zenrouter.dart';
 
 /// Mixin for routes that need to guard against being popped.
 ///
@@ -78,10 +80,10 @@ mixin RouteGuard on RouteTarget {
   /// }
   /// ```
   FutureOr<bool> popGuardWith(covariant Coordinator coordinator) {
-    assert(_path?.coordinator == coordinator, '''
-[RouteGuard] The path [${_path.toString()}] is associated with a different coordinator (or null) than the one currently handling the navigation.
+    assert(stackPath?.coordinator == coordinator, '''
+[RouteGuard] The path [${stackPath.toString()}] is associated with a different coordinator (or null) than the one currently handling the navigation.
 Expected coordinator: $coordinator
-Path's coordinator: ${_path?.coordinator}
+Path's coordinator: ${stackPath?.coordinator}
 Ensure that the path is created with the correct coordinator using `.createWith()` and that routes are being managed by the correct coordinator.
 ''');
     return popGuard();

--- a/packages/zenrouter/lib/src/mixin/query_parameters.dart
+++ b/packages/zenrouter/lib/src/mixin/query_parameters.dart
@@ -85,11 +85,8 @@ mixin RouteQueryParameters on RouteUnique {
   }
 
   @override
-  void onDidPop(
-    Object? result,
-    covariant Coordinator<RouteUnique>? coordinator,
-  ) {
-    super.onDidPop(result, coordinator);
+  void onDiscard() {
+    super.onDiscard();
     queryNotifier.dispose();
   }
 }

--- a/packages/zenrouter/lib/src/mixin/redirect.dart
+++ b/packages/zenrouter/lib/src/mixin/redirect.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
-import 'package:zenrouter/src/coordinator/base.dart';
-import 'package:zenrouter/src/path/base.dart';
+import 'package:zenrouter/zenrouter.dart';
 
 /// A mixin that provides redirection logic for routes.
 ///

--- a/packages/zenrouter/lib/src/mixin/target.dart
+++ b/packages/zenrouter/lib/src/mixin/target.dart
@@ -155,6 +155,8 @@ abstract class RouteTarget extends Equatable {
 
   @mustCallSuper
   void onDidPop(Object? result, covariant Coordinator? coordinator) {
+    onDiscard();
+
     /// Handle force pop from navigator
     if (isPopByPath == false && _path?.stack.contains(this) == true) {
       if (_path case StackMutatable path) {
@@ -178,6 +180,16 @@ abstract class RouteTarget extends Equatable {
     }
     _onResult.complete(result);
     _resultValue = result;
+    _path = null;
+  }
+
+  /// Call when the route is discarded.
+  ///
+  /// That is difference with [onDidPop], [onDidPop] called when route is removed from stack.
+  /// [onDiscard] called when route isn't in any path yet but it is in the process of being removed.
+  @mustCallSuper
+  void onDiscard() {
+    completeOnResult(null, null, true);
     _path = null;
   }
 }

--- a/packages/zenrouter/lib/src/mixin/target.dart
+++ b/packages/zenrouter/lib/src/mixin/target.dart
@@ -1,4 +1,8 @@
-part of '../path/base.dart';
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:zenrouter/src/internal/equatable.dart';
+import 'package:zenrouter/zenrouter.dart';
 
 /// The base class for all navigation targets (routes).
 ///
@@ -99,11 +103,12 @@ abstract class RouteTarget extends Equatable {
 
   /// Completer that resolves when this route is popped.
   ///
-  /// The future completes with the result passed to [pop] or [completeOnResult].
+  /// The future completes with the result passed to [completeOnResult].
   /// This is set fresh each time the route is pushed.
-  Completer<Object?> _onResult = Completer();
+  final Completer<Object?> _onResult = Completer();
 
   @visibleForTesting
+  @protected
   /// The completer for the result of the route. For testing purposes only.
   /// DO NOT USE THIS MANUALLY. USE [completeOnResult] instead.
   Completer<Object?> get onResult => _onResult;
@@ -114,11 +119,33 @@ abstract class RouteTarget extends Equatable {
   /// Used internally to ensure routes are managed by the correct path.
   StackPath? _path;
 
+  /// The [StackPath] that currently contains this route.
+  StackPath? get stackPath => _path;
+
+  /// Binds the route to a path.
+  ///
+  /// This is called internally when the route is pushed onto a path.
+  /// Useful when you want to create your custom [StackPath].
+  @protected
+  void bindStackPath(StackPath path) => _path = path;
+
+  /// Clears the path binding.
+  ///
+  /// This is called internally when the route is removed from a path.
+  @protected
+  void clearStackPath() => _path = null;
+
   /// The result value to be returned when this route is popped.
   ///
   /// This is set by [StackPath.pop] before [onDidPop] is called, allowing
   /// the widget tree to access the result during disposal.
   Object? _resultValue;
+
+  @protected
+  void bindResultValue(Object? value) => _resultValue = value;
+
+  /// The result value to be returned when this route is popped.
+  Object? get resultValue => _resultValue;
 
   /// Whether this route was popped by the path mechanism.
   ///
@@ -163,6 +190,8 @@ abstract class RouteTarget extends Equatable {
         path.remove(this);
       }
     }
+
+    clearStackPath();
   }
 
   /// Completes the route's result future.
@@ -173,14 +202,9 @@ abstract class RouteTarget extends Equatable {
     covariant Coordinator? coordinator, [
     bool failSilent = false,
   ]) {
-    if (failSilent && _onResult.isCompleted) {
-      _resultValue = null;
-      _path = null;
-      return;
-    }
+    if (failSilent && _onResult.isCompleted) return;
     _onResult.complete(result);
     _resultValue = result;
-    _path = null;
   }
 
   /// Call when the route is discarded.
@@ -190,6 +214,5 @@ abstract class RouteTarget extends Equatable {
   @mustCallSuper
   void onDiscard() {
     completeOnResult(null, null, true);
-    _path = null;
   }
 }

--- a/packages/zenrouter/lib/src/mixin/transition.dart
+++ b/packages/zenrouter/lib/src/mixin/transition.dart
@@ -1,6 +1,4 @@
-import 'package:zenrouter/src/coordinator/base.dart';
-import 'package:zenrouter/src/mixin/unique.dart';
-import 'package:zenrouter/src/path/base.dart';
+import 'package:zenrouter/zenrouter.dart';
 
 /// Mixin for routes that define a custom transition.
 mixin RouteTransition on RouteUnique {

--- a/packages/zenrouter/lib/src/mixin/unique.dart
+++ b/packages/zenrouter/lib/src/mixin/unique.dart
@@ -77,11 +77,4 @@ mixin RouteUnique on RouteTarget {
 
   /// Returns the URI representation of this route.
   Uri toUri();
-
-  @override
-  @mustCallSuper
-  void onDidPop(
-    Object? result,
-    covariant Coordinator<RouteUnique>? coordinator,
-  ) => super.onDidPop(result, coordinator);
 }

--- a/packages/zenrouter/lib/src/path/indexed.dart
+++ b/packages/zenrouter/lib/src/path/indexed.dart
@@ -1,4 +1,6 @@
-part of 'base.dart';
+// ignore_for_file: invalid_use_of_protected_member
+
+import 'package:zenrouter/zenrouter.dart';
 
 /// A fixed stack path for indexed navigation (like tabs).
 ///
@@ -12,7 +14,7 @@ class IndexedStackPath<T extends RouteTarget> extends StackPath<T>
     for (final path in stack) {
       /// Set the output of every route to null since this cannot pop
       path.completeOnResult(null, null);
-      path._path = this;
+      path.bindStackPath(this);
     }
   }
 

--- a/packages/zenrouter/lib/src/path/navigation.dart
+++ b/packages/zenrouter/lib/src/path/navigation.dart
@@ -1,4 +1,6 @@
-part of 'base.dart';
+// ignore_for_file: invalid_use_of_protected_member
+
+import 'package:zenrouter/zenrouter.dart';
 
 /// A mutable stack path for standard navigation.
 ///
@@ -54,7 +56,7 @@ class NavigationPath<T extends RouteTarget> extends StackPath<T>
   void reset() => clear();
 
   @override
-  T? get activeRoute => _stack.lastOrNull;
+  T? get activeRoute => stack.lastOrNull;
 
   @override
   Future<void> activateRoute(T route) async {
@@ -63,16 +65,7 @@ class NavigationPath<T extends RouteTarget> extends StackPath<T>
   }
 
   @override
-  void restore(dynamic data) {
-    final rawStack = (data as List).cast<RouteTarget>();
-
-    _stack.clear();
-    for (final route in rawStack) {
-      route.isPopByPath = false;
-      route._path = this;
-      _stack.add(route as T);
-    }
-  }
+  void restore(dynamic data) => bindStack(data.cast<RouteTarget>().cast<T>());
 
   @override
   List<dynamic> serialize() => [
@@ -84,7 +77,7 @@ class NavigationPath<T extends RouteTarget> extends StackPath<T>
     List<dynamic> data, [
     RouteUriParserSync<RouteUnique>? parseRouteFromUri,
   ]) {
-    parseRouteFromUri ??= _coordinator?.parseRouteFromUriSync;
+    parseRouteFromUri ??= coordinator?.parseRouteFromUriSync;
     return <T>[
       for (final routeRaw in data)
         RouteTarget.deserialize(routeRaw, parseRouteFromUri: parseRouteFromUri!)

--- a/packages/zenrouter/lib/src/path/stack.dart
+++ b/packages/zenrouter/lib/src/path/stack.dart
@@ -133,10 +133,9 @@ class _NavigationStackState<T extends RouteTarget>
 
           switch (didPop) {
             case true when result != null:
-              route.onDidPop(result, widget.coordinator);
               route.completeOnResult(result, widget.coordinator);
-            case true:
               route.onDidPop(result, widget.coordinator);
+            case true:
               route.completeOnResult(
                 route._resultValue,
                 widget.coordinator,
@@ -144,6 +143,7 @@ class _NavigationStackState<T extends RouteTarget>
                 /// Fail silently if it's a force pop from the platform.
                 route.isPopByPath == false,
               );
+              route.onDidPop(result, widget.coordinator);
             case false when route is RouteGuard:
               widget.path.pop();
             case false when destination.guard != null:

--- a/packages/zenrouter/lib/src/path/stack.dart
+++ b/packages/zenrouter/lib/src/path/stack.dart
@@ -1,4 +1,7 @@
-part of 'base.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:zenrouter/src/internal/diff.dart';
+import 'package:zenrouter/zenrouter.dart';
 
 /// A widget that renders a stack of pages based on a [NavigationPath].
 ///
@@ -111,7 +114,8 @@ class _NavigationStackState<T extends RouteTarget>
 
   Page _buildPage(T route) {
     /// Set path to route
-    route._path = widget.path;
+    // ignore: invalid_use_of_protected_member
+    route.bindStackPath(widget.path);
     final destination = widget.resolver(route);
     return destination.pageBuilder(
       context,
@@ -123,10 +127,11 @@ class _NavigationStackState<T extends RouteTarget>
           _ => true,
         },
         onPopInvokedWithResult: (didPop, result) async {
-          route._path ??= widget.path;
+          // ignore: invalid_use_of_protected_member
+          if (route.stackPath == null) route.bindStackPath(widget.path);
           if (!(kIsWeb || kIsWasm)) {
             assert(
-              identical(route._path, widget.path),
+              identical(route.stackPath, widget.path),
               'Route must be from the same path',
             );
           }
@@ -136,8 +141,9 @@ class _NavigationStackState<T extends RouteTarget>
               route.completeOnResult(result, widget.coordinator);
               route.onDidPop(result, widget.coordinator);
             case true:
+              result = route.resultValue;
               route.completeOnResult(
-                route._resultValue,
+                result,
                 widget.coordinator,
 
                 /// Fail silently if it's a force pop from the platform.

--- a/packages/zenrouter/lib/src/path/transition.dart
+++ b/packages/zenrouter/lib/src/path/transition.dart
@@ -1,4 +1,6 @@
-part of 'base.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:zenrouter/zenrouter.dart';
 
 /// Defines how a route should be displayed as a widget and wrapped in a page.
 ///

--- a/packages/zenrouter/lib/zenrouter.dart
+++ b/packages/zenrouter/lib/zenrouter.dart
@@ -7,9 +7,15 @@ export 'src/coordinator/router.dart';
 
 /// Path base
 export 'src/path/base.dart';
+export 'src/path/navigation.dart';
 export 'src/path/restoration.dart';
+export 'src/path/indexed.dart';
+export 'src/path/stack.dart';
+export 'src/path/transition.dart';
 
 /// Route target capabilities
+export 'src/mixin/target.dart';
+export 'src/mixin/guard.dart';
 export 'src/mixin/deeplink.dart';
 export 'src/mixin/layout.dart';
 export 'src/mixin/query_parameters.dart';


### PR DESCRIPTION
This pull request refactors the ZenRouter navigation stack to improve route lifecycle management, clarify route-path relationships, and standardize imports. The main changes introduce explicit methods for binding and clearing the association between routes and their containing paths, add a new `onDiscard` lifecycle method, and clean up internal API usage. These changes aim to make route management more robust and maintainable.

**Route and Path Lifecycle Management:**

* Added `bindStackPath`, `clearStackPath`, and `bindResultValue` methods to `RouteTarget`, making the association between a route and its containing `StackPath` explicit and easier to manage. Also, introduced a `stackPath` getter for safer access. [[1]](diffhunk://#diff-75fc20d42e655b9907bb508e0c8439876dfb5247d2daf142648788e33f92f7a7R122-R149) [[2]](diffhunk://#diff-7041468e63f4861d76ab2fdd1428f6f23e0276162b704ed313354dd0ba9b084eL57-R52) [[3]](diffhunk://#diff-7041468e63f4861d76ab2fdd1428f6f23e0276162b704ed313354dd0ba9b084eL73-R73) [[4]](diffhunk://#diff-7041468e63f4861d76ab2fdd1428f6f23e0276162b704ed313354dd0ba9b084eL135-R132) [[5]](diffhunk://#diff-c71d8c6f1d3da34ab0ea076f1df9965f3227f8685ba605249258d2eb0b061d40L15-R17) [[6]](diffhunk://#diff-7a7d6f395bcbc46ec4c8f4e76b9e7dcd43a4648e8e73866efa8a3c1ef970f1b6L114-R118)
* Introduced a new `onDiscard` method in `RouteTarget` to handle cleanup when a route is discarded (not just popped), and updated usages throughout the codebase to call this method appropriately. [[1]](diffhunk://#diff-75fc20d42e655b9907bb508e0c8439876dfb5247d2daf142648788e33f92f7a7L174-R216) [[2]](diffhunk://#diff-5aaf5e19c3c7dc777c36d3321dfc18d8035b4bb99df210aae8732ee17e2bbeedL88-R89) [[3]](diffhunk://#diff-7041468e63f4861d76ab2fdd1428f6f23e0276162b704ed313354dd0ba9b084eL73-R73) [[4]](diffhunk://#diff-9ba588aef0a50505064cc31c0ebfe44e2f97381e7575a88a803caf34045625e2R472-R474)

**StackPath and Navigation Improvements:**

* Added a `bindStack` method to `StackPath` for safely initializing the stack and binding all routes to the path, and updated `restore` and related logic to use this. [[1]](diffhunk://#diff-7041468e63f4861d76ab2fdd1428f6f23e0276162b704ed313354dd0ba9b084eR226-R235) [[2]](diffhunk://#diff-814603b98cfb925e1d1acb9f7ea842e3f3fc481b1162336e030c35b7f55132f9L66-R68)
* Updated factory constructors and methods for `NavigationPath` and `IndexedStackPath` to use new `create` methods, improving clarity and consistency.

**Internal API and Import Refactoring:**

* Replaced internal relative imports with public `zenrouter.dart` imports across all files for cleaner and more maintainable code. [[1]](diffhunk://#diff-9ba588aef0a50505064cc31c0ebfe44e2f97381e7575a88a803caf34045625e2L5-R5) [[2]](diffhunk://#diff-a6cff4c4a3c0dfd6b0583c68c4acb4cc6eb0ae14752eeb829eeea330175d9efcL1-R1) [[3]](diffhunk://#diff-d8ecfd6b8bea5955ff52512b1328011ea1d677ac5c14ceb056318f19eb64a76aL1-R3) [[4]](diffhunk://#diff-059b3f42e22c17db8e29fe4916c79c227d2595afd758b757fc60d01748c40ddaL3-R3) [[5]](diffhunk://#diff-10b847152fd023d2162f61fbe282f46f1d84c8ac9b0c4b4f96f8a09312e30d62L1-R1) [[6]](diffhunk://#diff-c71d8c6f1d3da34ab0ea076f1df9965f3227f8685ba605249258d2eb0b061d40L1-R3) [[7]](diffhunk://#diff-814603b98cfb925e1d1acb9f7ea842e3f3fc481b1162336e030c35b7f55132f9L1-R3) [[8]](diffhunk://#diff-7a7d6f395bcbc46ec4c8f4e76b9e7dcd43a4648e8e73866efa8a3c1ef970f1b6L1-R4) [[9]](diffhunk://#diff-7041468e63f4861d76ab2fdd1428f6f23e0276162b704ed313354dd0ba9b084eR1-L16)

**RouteGuard and Query Parameters:**

* Updated `RouteGuard` to use the new `stackPath` property instead of the internal `_path`, improving encapsulation and error messages.
* Changed `RouteQueryParameters` to dispose its notifier in `onDiscard` instead of `onDidPop`, aligning with the new lifecycle.

**Miscellaneous:**

* Improved testability and protected member usage, added ignore comments for internal/protected member access, and made minor doc and assertion improvements. [[1]](diffhunk://#diff-7041468e63f4861d76ab2fdd1428f6f23e0276162b704ed313354dd0ba9b084eR1-L16) [[2]](diffhunk://#diff-c71d8c6f1d3da34ab0ea076f1df9965f3227f8685ba605249258d2eb0b061d40L1-R3) [[3]](diffhunk://#diff-814603b98cfb925e1d1acb9f7ea842e3f3fc481b1162336e030c35b7f55132f9L1-R3) [[4]](diffhunk://#diff-9e7c37bc052e3fec5c61cdc54f183b0727468e6f5636fd55eab2d90c55fe2f67R261-R266)

Let me know if you want to dive deeper into any of these changes!