### PR TITLE
feat: add must call super to paths in coordinator

### DIFF
--- a/packages/zenrouter/doc/paradigms/coordinator/example/lib/routes/coordinator.dart
+++ b/packages/zenrouter/doc/paradigms/coordinator/example/lib/routes/coordinator.dart
@@ -18,7 +18,7 @@ class AppCoordinator extends Coordinator<AppRoute> {
 
   @override
   List<StackPath<RouteTarget>> get paths => [
-    root,
+    ...super.paths,
     homeIndexed,
     feedNavigation,
     profileNavigation,

--- a/packages/zenrouter/example/lib/main.dart
+++ b/packages/zenrouter/example/lib/main.dart
@@ -298,7 +298,11 @@ class AppCoordinator extends Coordinator<AppRoute> with CoordinatorDebug {
   );
 
   @override
-  List<StackPath<RouteTarget>> get paths => [root, customIndexed, firstStack];
+  List<StackPath<RouteTarget>> get paths => [
+    ...super.paths,
+    customIndexed,
+    firstStack,
+  ];
 
   @override
   void defineLayout() {

--- a/packages/zenrouter/example/lib/main_coordinator.dart
+++ b/packages/zenrouter/example/lib/main_coordinator.dart
@@ -512,7 +512,7 @@ class AppCoordinator extends Coordinator<AppRoute> with CoordinatorDebug {
 
   @override
   List<StackPath> get paths => [
-    root,
+    ...super.paths,
     homeStack,
     settingsStack,
     tabIndexed,

--- a/packages/zenrouter/lib/src/coordinator/base.dart
+++ b/packages/zenrouter/lib/src/coordinator/base.dart
@@ -170,6 +170,7 @@ abstract class Coordinator<T extends RouteUnique> extends Equatable
   /// All navigation paths managed by this coordinator.
   ///
   /// If you add custom paths, make sure to override [paths]
+  @mustCallSuper
   List<StackPath> get paths => [root];
 
   /// Defines the layout structure for this coordinator.

--- a/packages/zenrouter/test/coordinator/error_test.dart
+++ b/packages/zenrouter/test/coordinator/error_test.dart
@@ -189,7 +189,7 @@ class ErrorTestCoordinator extends Coordinator<ErrorTestRoute> {
   }
 
   @override
-  List<StackPath> get paths => [root, testStack];
+  List<StackPath> get paths => [...super.paths, testStack];
 
   @override
   ErrorTestRoute parseRouteFromUri(Uri uri) {

--- a/packages/zenrouter/test/coordinator/navigation_test.dart
+++ b/packages/zenrouter/test/coordinator/navigation_test.dart
@@ -139,7 +139,7 @@ class TestCoordinator extends Coordinator<AppRoute> {
   );
 
   @override
-  List<StackPath> get paths => [root, tabStack];
+  List<StackPath> get paths => [...super.paths, tabStack];
 
   @override
   void defineLayout() {

--- a/packages/zenrouter/test/coordinator/restoration_test.dart
+++ b/packages/zenrouter/test/coordinator/restoration_test.dart
@@ -218,7 +218,7 @@ class TestCoordinator extends Coordinator<AppRoute> {
   );
 
   @override
-  List<StackPath> get paths => [root, tabStack, undefinedTabStack];
+  List<StackPath> get paths => [...super.paths, tabStack, undefinedTabStack];
 
   @override
   void defineLayout() {

--- a/packages/zenrouter/test/coordinator/router_delegate_test.dart
+++ b/packages/zenrouter/test/coordinator/router_delegate_test.dart
@@ -147,7 +147,7 @@ class TestCoordinator extends Coordinator<AppRoute> {
   );
 
   @override
-  List<StackPath> get paths => [root, tabStack];
+  List<StackPath> get paths => [...super.paths, tabStack];
 
   @override
   void defineLayout() {

--- a/packages/zenrouter/test/mixin/layout_test.dart
+++ b/packages/zenrouter/test/mixin/layout_test.dart
@@ -194,7 +194,7 @@ class LayoutTestCoordinator extends Coordinator<LayoutTestRoute> {
   }
 
   @override
-  List<StackPath> get paths => [root, allowPopPath];
+  List<StackPath> get paths => [...super.paths, allowPopPath];
 
   @override
   LayoutTestRoute parseRouteFromUri(Uri uri) {

--- a/packages/zenrouter/test/mixin/mixin_test_utils.dart
+++ b/packages/zenrouter/test/mixin/mixin_test_utils.dart
@@ -755,7 +755,7 @@ class MixinTestCoordinator extends Coordinator<TestAppRoute> {
   void defineLayout() {}
 
   @override
-  List<StackPath> get paths => [root];
+  List<StackPath> get paths => [...super.paths];
 
   @override
   TestAppRoute parseRouteFromUri(Uri uri) {

--- a/packages/zenrouter/test/path/indexed_test.dart
+++ b/packages/zenrouter/test/path/indexed_test.dart
@@ -153,7 +153,7 @@ class IndexedTestCoordinator extends Coordinator<IndexedTestRoute> {
   );
 
   @override
-  List<StackPath<RouteTarget>> get paths => [root, indexed];
+  List<StackPath<RouteTarget>> get paths => [...super.paths, indexed];
 
   @override
   void defineLayout() {

--- a/packages/zenrouter/test/path/restoration_test.dart
+++ b/packages/zenrouter/test/path/restoration_test.dart
@@ -105,6 +105,7 @@ class DummyCoordinator extends Coordinator<RouteUnique> {
   RouteUnique parseRouteFromUri(Uri uri) => TestRoute(uri.path);
 
   @override
+  // ignore: must_call_super
   List<StackPath<RouteTarget>> get paths => [];
 }
 

--- a/packages/zenrouter/test/stack/full_flow_test.dart
+++ b/packages/zenrouter/test/stack/full_flow_test.dart
@@ -438,7 +438,7 @@ class TestCoordinator extends Coordinator<AppRoute> {
 
   @override
   List<StackPath> get paths => [
-    root,
+    ...super.paths,
     shellStack,
     tabStack,
     profileStack,

--- a/packages/zenrouter/test/stack/layout_creation_test.dart
+++ b/packages/zenrouter/test/stack/layout_creation_test.dart
@@ -210,7 +210,7 @@ class TestCoordinator extends Coordinator<TestRoute> {
 
   @override
   List<StackPath> get paths => [
-    root,
+    ...super.paths,
     homeStack,
     settingsStack,
     tabIndexed,

--- a/packages/zenrouter/test/stack/route_completion_test.dart
+++ b/packages/zenrouter/test/stack/route_completion_test.dart
@@ -14,7 +14,7 @@ class TestCoordinator extends Coordinator<TestRoute> {
   void defineLayout() {}
 
   @override
-  List<StackPath> get paths => [root];
+  List<StackPath> get paths => [...super.paths];
 
   @override
   TestRoute parseRouteFromUri(Uri uri) {

--- a/packages/zenrouter_file_generator/example/lib/routes/routes.zen.dart
+++ b/packages/zenrouter_file_generator/example/lib/routes/routes.zen.dart
@@ -75,7 +75,7 @@ class AppCoordinator extends Coordinator<AppRoute> {
 
   @override
   List<StackPath> get paths => [
-    root,
+    ...super.paths,
     authPath,
     tabsPath,
     feedTabPath,

--- a/packages/zenrouter_file_generator/lib/src/generators/coordinator_generator.dart
+++ b/packages/zenrouter_file_generator/lib/src/generators/coordinator_generator.dart
@@ -693,7 +693,7 @@ class CoordinatorGenerator implements Builder {
 
     // Generate paths getter
     buffer.writeln('  @override');
-    buffer.write('  List<StackPath> get paths => [root');
+    buffer.write('  List<StackPath> get paths => [...super.paths');
     for (final layout in tree.layouts) {
       buffer.write(', ${_getPathFieldName(layout.className)}');
     }


### PR DESCRIPTION
Using `@mustCallSuper` ensures that `root` won't be forgotten when `paths` is overridden