### PR TITLE
[zenrouter_devtools] Add dependency on `cupertino_icons`

### DIFF
--- a/packages/zenrouter_devtools/example/pubspec.lock
+++ b/packages/zenrouter_devtools/example/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
@@ -127,18 +127,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
@@ -220,10 +220,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
@@ -265,5 +265,5 @@ packages:
     source: hosted
     version: "0.1.3"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.8.1 <4.0.0"
   flutter: ">=3.32.0"

--- a/packages/zenrouter_devtools/pubspec.yaml
+++ b/packages/zenrouter_devtools/pubspec.yaml
@@ -17,6 +17,7 @@ topics:
 resolution: workspace
 
 dependencies:
+  cupertino_icons: ^1.0.8
   flutter:
     sdk: flutter
   zenrouter: ^0.4.14


### PR DESCRIPTION
Thanks for a fresh & unique routing solution!

I noticed that the `zenrouter_devtools` package is using CupertinoIcons for its overlay, but it doesn't depend on `cupertino_icons` itself. This can cause all the icons to be replaced with a question mark box placeholder if the app itself doesn't add the dependency.

<hr>

## Before

<img width="407" height="504" alt="devtools_before" src="https://github.com/user-attachments/assets/d5e8cce4-ed13-4815-a194-5fa0cf771379" />

<hr>

## After

<img width="408" height="504" alt="devtools_after" src="https://github.com/user-attachments/assets/26ee7d8b-c4e5-4be2-a796-8afd0c8de113" />