### PR TITLE
feat: Implement `CoordinatorModular` and `RouteModule` for breaking down `Coordinator` into module and smaller chunk

### DIFF
--- a/packages/zenrouter/doc/guides/coordinator-modular.md
+++ b/packages/zenrouter/doc/guides/coordinator-modular.md
@@ -1,0 +1,650 @@
+# Modular Coordinator Guide
+
+> **Split your coordinator into independent, reusable modules**
+
+The Modular Coordinator pattern enables you to organize routes by domain or feature, making large applications more maintainable and allowing teams to work independently on different parts of your app.
+
+## What is Modular Coordinator?
+
+`CoordinatorModular` is a mixin that extends `Coordinator` with the ability to delegate route management to multiple `RouteModule` instances. Each module handles a specific subset of routes, paths, layouts, and converters.
+
+**Key concepts:**
+- **RouteModule**: A self-contained unit that handles routes for a specific domain
+- **CoordinatorModular**: Aggregates modules and delegates route parsing
+- **Module Isolation**: Each module manages its own paths and layouts independently
+
+### When to Use Modular Coordinator
+
+✅ **Use when:**
+- Building large applications with many routes
+- Working with multiple teams on different features
+- You want to organize routes by domain (auth, shop, settings, etc.)
+- You need to reuse route modules across applications
+- Your `parseRouteFromUri` method is becoming too large
+
+❌ **Don't use when:**
+- Your app has fewer than ~10 routes
+- All routes belong to a single domain
+- You prefer a single, centralized route parser
+
+---
+
+## Quick Start
+
+### Step 1: Create Your Route Modules
+
+Each module extends `RouteModule` and handles routes for a specific domain:
+
+```dart
+// lib/modules/auth_module.dart
+class AuthModule extends RouteModule<AppRoute> {
+  AuthModule(super.coordinator);
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      ['auth', 'login'] => LoginRoute(),
+      ['auth', 'register'] => RegisterRoute(),
+      _ => null, // Not handled by this module
+    };
+  }
+
+  @override
+  void defineLayout() {
+    // Register auth-specific layouts
+    RouteLayout.defineLayout(AuthLayout, AuthLayout.new);
+  }
+}
+
+// lib/modules/shop_module.dart
+class ShopModule extends RouteModule<AppRoute> {
+  ShopModule(super.coordinator);
+
+  // Module can define its own navigation paths
+  late final NavigationPath<AppRoute> shopPath = NavigationPath.createWith(
+    label: 'shop',
+    coordinator: coordinator,
+  );
+
+  @override
+  List<StackPath> get paths => [shopPath];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      ['shop'] => ShopHomeRoute(),
+      ['shop', 'products', final id] => ProductRoute(id: id),
+      ['shop', 'cart'] => CartRoute(),
+      _ => null,
+    };
+  }
+
+  @override
+  void defineLayout() {
+    RouteLayout.defineLayout(ShopLayout, ShopLayout.new);
+  }
+}
+```
+
+### Step 2: Create Your Modular Coordinator
+
+Use the `CoordinatorModular` mixin and implement `defineModules`:
+
+```dart
+// lib/coordinator.dart
+class AppCoordinator extends Coordinator<AppRoute>
+    with CoordinatorModular<AppRoute> {
+  
+  @override
+  Set<RouteModule<AppRoute>> defineModules(
+    CoordinatorModular<AppRoute> coordinator,
+  ) {
+    return {
+      AuthModule(coordinator),
+      ShopModule(coordinator),
+      SettingsModule(coordinator),
+    };
+  }
+
+  @override
+  AppRoute notFoundRoute(Uri uri) {
+    return NotFoundRoute(uri: uri);
+  }
+}
+```
+
+### Step 3: Use in Your App
+
+The coordinator works exactly like a regular coordinator:
+
+```dart
+final coordinator = AppCoordinator();
+
+MaterialApp.router(
+  routerConfig: coordinator,
+)
+```
+
+**That's it!** Routes are now parsed by modules in order until one matches.
+
+---
+
+## How Route Parsing Works
+
+When `parseRouteFromUri` is called, the coordinator:
+
+1. **Iterates through modules** in the order they appear in `defineModules`
+2. **Calls each module's `parseRouteFromUri`** until one returns a non-null route
+3. **Returns the first match** found
+4. **Calls `notFoundRoute`** if all modules return null
+
+**Example flow:**
+
+```dart
+// URI: /shop/products/123
+coordinator.parseRouteFromUri(Uri.parse('/shop/products/123'));
+
+// 1. AuthModule.parseRouteFromUri() → returns null (not handled)
+// 2. ShopModule.parseRouteFromUri() → returns ProductRoute(id: '123') ✅
+// 3. Returns ProductRoute immediately (doesn't check SettingsModule)
+```
+
+**Important:** Module order matters! The first module that returns a non-null route wins.
+
+---
+
+## Complete Example
+
+Here's a full example showing multiple modules with layouts and paths:
+
+```dart
+// ============================================================================
+// Route Base
+// ============================================================================
+
+abstract class AppRoute extends RouteTarget with RouteUnique {}
+
+// ============================================================================
+// Auth Module
+// ============================================================================
+
+class AuthModule extends RouteModule<AppRoute> {
+  AuthModule(super.coordinator);
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      ['login'] => LoginRoute(),
+      ['register'] => RegisterRoute(),
+      _ => null,
+    };
+  }
+}
+
+class LoginRoute extends AppRoute {
+  @override
+  Uri toUri() => Uri.parse('/login');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => coordinator.replace(ShopHomeRoute()),
+          child: const Text('Login'),
+        ),
+      ),
+    );
+  }
+}
+
+class RegisterRoute extends AppRoute {
+  @override
+  Uri toUri() => Uri.parse('/register');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: const Center(child: Text('Register Page')),
+    );
+  }
+}
+
+// ============================================================================
+// Shop Module
+// ============================================================================
+
+class ShopModule extends RouteModule<AppRoute> {
+  ShopModule(super.coordinator);
+
+  late final NavigationPath<AppRoute> shopPath = NavigationPath.createWith(
+    label: 'shop',
+    coordinator: coordinator,
+  );
+
+  @override
+  List<StackPath> get paths => [shopPath];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      ['shop'] => ShopHomeRoute(),
+      ['shop', 'products', final id] => ProductRoute(id: id),
+      _ => null,
+    };
+  }
+
+  @override
+  void defineLayout() {
+    RouteLayout.defineLayout(ShopLayout, ShopLayout.new);
+  }
+}
+
+class ShopLayout extends AppRoute with RouteLayout<AppRoute> {
+  @override
+  NavigationPath<AppRoute> resolvePath(AppCoordinator coordinator) {
+    final shopModule = coordinator.getModule<ShopModule>() as ShopModule;
+    return shopModule.shopPath;
+  }
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Shop')),
+      body: buildPath(coordinator),
+    );
+  }
+}
+
+class ShopHomeRoute extends AppRoute {
+  @override
+  Type get layout => ShopLayout;
+
+  @override
+  Uri toUri() => Uri.parse('/shop');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return ListView(
+      children: [
+        ListTile(
+          title: const Text('Product 1'),
+          onTap: () => coordinator.push(ProductRoute(id: '1')),
+        ),
+      ],
+    );
+  }
+}
+
+class ProductRoute extends AppRoute {
+  ProductRoute({required this.id});
+  final String id;
+
+  @override
+  Type get layout => ShopLayout;
+
+  @override
+  Uri toUri() => Uri.parse('/shop/products/$id');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Product $id')),
+      body: Center(child: Text('Product Detail: $id')),
+    );
+  }
+
+  @override
+  List<Object?> get props => [id];
+}
+
+// ============================================================================
+// Coordinator
+// ============================================================================
+
+class AppCoordinator extends Coordinator<AppRoute>
+    with CoordinatorModular<AppRoute> {
+  
+  @override
+  Set<RouteModule<AppRoute>> defineModules(
+    CoordinatorModular<AppRoute> coordinator,
+  ) {
+    return {
+      AuthModule(coordinator),
+      ShopModule(coordinator),
+    };
+  }
+
+  @override
+  AppRoute notFoundRoute(Uri uri) {
+    return NotFoundRoute(uri: uri);
+  }
+}
+
+class NotFoundRoute extends AppRoute {
+  NotFoundRoute({required this.uri});
+  final Uri uri;
+
+  @override
+  Uri toUri() => Uri.parse('/not-found');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Not Found')),
+      body: Center(child: Text('Route not found: ${uri.path}')),
+    );
+  }
+}
+```
+
+---
+
+## Accessing Modules
+
+Use `getModule()` to access module-specific functionality:
+
+```dart
+final coordinator = AppCoordinator();
+
+// Access a specific module
+final shopModule = coordinator.getModule<ShopModule>();
+
+// Use module-specific paths
+shopModule.shopPath.push(ProductRoute(id: '123'));
+
+// Access module properties
+final shopPath = shopModule.shopPath;
+```
+
+**Use case:** When you need to navigate within a specific module's path or access module-specific functionality.
+
+---
+
+## Module Responsibilities
+
+Each module can handle:
+
+### 1. Route Parsing
+
+Override `parseRouteFromUri` to handle specific URI patterns:
+
+```dart
+@override
+FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+  return switch (uri.pathSegments) {
+    ['my', 'route'] => MyRoute(),
+    _ => null, // Let other modules handle it
+  };
+}
+```
+
+**Best practice:** Return `null` for routes you don't handle. This allows other modules to process them.
+
+### 2. Navigation Paths
+
+Override `paths` to provide paths for nested navigation:
+
+```dart
+late final NavigationPath<AppRoute> myPath = NavigationPath.createWith(
+  label: 'my-module',
+  coordinator: coordinator,
+);
+
+@override
+List<StackPath> get paths => [myPath];
+```
+
+**Important:** Always use `.createWith()` to bind paths to the coordinator.
+
+### 3. Layout Registration
+
+Override `defineLayout` to register layouts:
+
+```dart
+@override
+void defineLayout() {
+  RouteLayout.defineLayout(MyLayout, MyLayout.new);
+}
+```
+
+### 4. Converter Registration
+
+Override `defineConverter` to register restorable converters:
+
+```dart
+@override
+void defineConverter() {
+  RestorableConverter.defineConverter(
+    MyRoute,
+    (json) => MyRoute.fromJson(json),
+    (route) => route.toJson(),
+  );
+}
+```
+
+---
+
+## Module Order Matters
+
+Modules are checked in the order they appear in the `Set` returned by `defineModules`. This allows you to:
+
+- **Prioritize certain modules** (e.g., admin routes checked before public routes)
+- **Handle route conflicts** (first module wins)
+- **Create fallback chains** (specific modules before general ones)
+
+**Example: Admin routes take precedence**
+
+```dart
+@override
+Set<RouteModule<AppRoute>> defineModules(
+  CoordinatorModular<AppRoute> coordinator,
+) {
+  return {
+    AdminModule(coordinator),    // Checked first
+    PublicModule(coordinator),   // Checked second
+  };
+}
+```
+
+If both modules could handle `/users`, AdminModule wins because it's checked first.
+
+---
+
+## Path Aggregation
+
+All module paths are automatically aggregated into the coordinator's `paths`:
+
+```dart
+class AppCoordinator extends Coordinator<AppRoute>
+    with CoordinatorModular<AppRoute> {
+  // ... defineModules ...
+
+  // Paths automatically include:
+  // - coordinator.root (from super.paths)
+  // - shopModule.shopPath (from ShopModule)
+  // - settingsModule.settingsPath (from SettingsModule)
+}
+```
+
+You can access all paths through `coordinator.paths`, and they're all available for state restoration.
+
+---
+
+## Best Practices
+
+### ✅ Do
+
+- **Return null** when a module doesn't handle a route
+- **Use descriptive module names** (AuthModule, ShopModule, not Module1, Module2)
+- **Keep modules focused** on a single domain or feature
+- **Use `.createWith()`** for all paths to ensure proper binding
+- **Provide unique labels** for paths (required for state restoration)
+- **Order modules logically** (specific before general, admin before public)
+
+### ❌ Don't
+
+- **Don't handle routes outside your domain** (return null instead)
+- **Don't create circular dependencies** between modules
+- **Don't access other modules directly** (use `getModule()` instead)
+- **Don't forget to return null** for unhandled routes
+- **Don't create paths without binding** to the coordinator
+
+---
+
+## Advanced Patterns
+
+### Module with Multiple Paths
+
+A module can manage multiple paths:
+
+```dart
+class ShopModule extends RouteModule<AppRoute> {
+  ShopModule(super.coordinator);
+
+  late final NavigationPath<AppRoute> productsPath = NavigationPath.createWith(
+    label: 'products',
+    coordinator: coordinator,
+  );
+
+  late final NavigationPath<AppRoute> cartPath = NavigationPath.createWith(
+    label: 'cart',
+    coordinator: coordinator,
+  );
+
+  @override
+  List<StackPath> get paths => [productsPath, cartPath];
+}
+```
+
+### Module with Async Parsing
+
+Modules can use async parsing for dynamic route resolution:
+
+```dart
+@override
+Future<AppRoute?> parseRouteFromUri(Uri uri) async {
+  if (uri.pathSegments.first == 'dynamic') {
+    // Fetch data from API
+    final data = await fetchRouteData(uri);
+    return DynamicRoute(data: data);
+  }
+  return null;
+}
+```
+
+### Module with Conditional Registration
+
+Register modules conditionally:
+
+```dart
+@override
+Set<RouteModule<AppRoute>> defineModules(
+  CoordinatorModular<AppRoute> coordinator,
+) {
+  final modules = <RouteModule<AppRoute>>{
+    AuthModule(coordinator),
+    ShopModule(coordinator),
+  };
+
+  // Add admin module only if user is admin
+  if (userService.isAdmin) {
+    modules.add(AdminModule(coordinator));
+  }
+
+  return modules;
+}
+```
+
+---
+
+## Troubleshooting
+
+### Error: "TypeError: type 'X' is not a subtype of type 'Y'"
+
+**Problem:** Trying to access a module that wasn't registered.
+
+**Solution:** Ensure the module is included in `defineModules`:
+
+```dart
+@override
+Set<RouteModule<AppRoute>> defineModules(...) {
+  return {
+    MyModule(coordinator), // ✅ Must be included
+  };
+}
+```
+
+### Routes Not Being Parsed
+
+**Check:**
+1. Module is included in `defineModules`
+2. Module's `parseRouteFromUri` returns non-null for the route
+3. Module appears before other modules that might handle the same route
+4. Route URI matches the pattern in the module
+
+**Debug tip:** Add logging to see which modules are checked:
+
+```dart
+@override
+FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+  print('AuthModule checking: ${uri.path}');
+  return switch (uri.pathSegments) {
+    ['auth', 'login'] => LoginRoute(),
+    _ => null,
+  };
+}
+```
+
+### Path Not Found
+
+**Problem:** Module path not accessible or not aggregated.
+
+**Solution:**
+1. Ensure path is returned in module's `paths` getter
+2. Use `.createWith()` to bind path to coordinator
+3. Check that module is registered in `defineModules`
+
+### Layout Not Registered
+
+**Problem:** Layout constructor not found.
+
+**Solution:** Register layout in module's `defineLayout`:
+
+```dart
+@override
+void defineLayout() {
+  RouteLayout.defineLayout(MyLayout, MyLayout.new); // ✅ Required
+}
+```
+
+---
+
+## Comparison: Regular vs Modular Coordinator
+
+| Aspect | Regular Coordinator | Modular Coordinator |
+|--------|-------------------|---------------------|
+| **Route Parsing** | Single `parseRouteFromUri` method | Delegated to modules |
+| **Code Organization** | All routes in one place | Routes organized by module |
+| **Team Collaboration** | Requires coordination | Teams work independently |
+| **Scalability** | Becomes unwieldy with many routes | Scales well with many routes |
+| **Reusability** | Routes tied to coordinator | Modules can be reused |
+| **Complexity** | Simpler for small apps | Better for large apps |
+
+**Migration:** You can migrate from regular to modular coordinator incrementally by extracting routes into modules one at a time.
+
+---
+
+## Next Steps
+
+- **See [route-layout.md](./route-layout.md)** for creating nested navigation layouts
+- **See [state-restoration.md](./state-restoration.md)** for persisting navigation state
+- **See [query-parameters.md](./query-parameters.md)** for handling URL parameters
+- **Check example code** in `packages/zenrouter/example/lib/main_modular.dart`
+- **Read API docs** for [RouteModule](../api/coordinator.md#routemodule) and [CoordinatorModular](../api/coordinator.md#coordinatormodular)
+
+---
+
+**Need help?** File an issue at [github.com/definev/zenrouter/issues](https://github.com/definev/zenrouter/issues)

--- a/packages/zenrouter/example/lib/main_modular.dart
+++ b/packages/zenrouter/example/lib/main_modular.dart
@@ -1,0 +1,757 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:zenrouter/zenrouter.dart';
+import 'package:zenrouter_devtools/zenrouter_devtools.dart';
+
+// ============================================================================
+// Main App Entry Point
+// ============================================================================
+
+void main() {
+  runApp(const ModularApp());
+}
+
+class ModularApp extends StatelessWidget {
+  const ModularApp({super.key});
+
+  static final coordinator = AppCoordinator();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: 'ZenRouter Modular Coordinator Example',
+      restorationScopeId: 'modular_coordinator',
+      routerDelegate: coordinator.routerDelegate,
+      routeInformationParser: coordinator.routeInformationParser,
+    );
+  }
+}
+
+// ============================================================================
+// Route Base Class
+// ============================================================================
+
+abstract class AppRoute extends RouteTarget with RouteUnique {}
+
+// ============================================================================
+// Auth Module - Handles authentication routes
+// ============================================================================
+
+class AuthModule extends RouteModule<AppRoute> {
+  AuthModule(super.coordinator);
+
+  // Auth module doesn't define any paths (uses root path)
+  @override
+  List<StackPath> get paths => [];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      ['login'] => LoginRoute(),
+      ['register'] => RegisterRoute(),
+      _ => null, // Not handled by this module
+    };
+  }
+
+  @override
+  void defineLayout() {
+    // Auth module doesn't define layouts
+  }
+}
+
+// Auth Routes
+class LoginRoute extends AppRoute {
+  @override
+  Uri toUri() => Uri.parse('/login');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Login Page', style: TextStyle(fontSize: 24)),
+            const SizedBox(height: 32),
+            ElevatedButton(
+              onPressed: () => coordinator.replace(ShopHomeRoute()),
+              child: const Text('Login & Go to Shop'),
+            ),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: () => coordinator.push(RegisterRoute()),
+              child: const Text('Go to Register'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class RegisterRoute extends AppRoute {
+  @override
+  Uri toUri() => Uri.parse('/register');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Register Page', style: TextStyle(fontSize: 24)),
+            const SizedBox(height: 32),
+            ElevatedButton(
+              onPressed: () => coordinator.pop(),
+              child: const Text('Back to Login'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ============================================================================
+// Shop Module - Handles shop/product routes with nested navigation
+// ============================================================================
+
+class ShopModule extends RouteModule<AppRoute> {
+  ShopModule(super.coordinator);
+
+  // Shop module defines its own navigation path
+  late final NavigationPath<AppRoute> shopStack = NavigationPath.createWith(
+    label: 'shop',
+    coordinator: coordinator,
+  );
+
+  @override
+  List<StackPath> get paths => [shopStack];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      ['shop'] => ShopHomeRoute(),
+      ['shop', 'products'] => ProductListRoute(),
+      ['shop', 'products', final id] => ProductDetailRoute(id: id),
+      ['shop', 'cart'] => CartRoute(),
+      _ => null, // Not handled by this module
+    };
+  }
+
+  @override
+  void defineLayout() {
+    // Register shop layout
+    RouteLayout.defineLayout(ShopLayout, ShopLayout.new);
+  }
+}
+
+// Shop Layout - Provides navigation shell for shop routes
+class ShopLayout extends AppRoute with RouteLayout<AppRoute> {
+  @override
+  NavigationPath<AppRoute> resolvePath(AppCoordinator coordinator) {
+    final shopModule = coordinator.getModule<ShopModule>() as ShopModule;
+    return shopModule.shopStack;
+  }
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Shop'), backgroundColor: Colors.green),
+      body: buildPath(coordinator),
+      bottomNavigationBar: ListenableBuilder(
+        listenable: resolvePath(coordinator),
+        builder: (context, _) {
+          return Container(
+            color: Colors.grey[200],
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                _ShopNavButton(
+                  icon: Icons.home,
+                  label: 'Home',
+                  isActive: coordinator.activePath.stack.last is ShopHomeRoute,
+                  onTap: () => coordinator.push(ShopHomeRoute()),
+                ),
+                _ShopNavButton(
+                  icon: Icons.shopping_bag,
+                  label: 'Products',
+                  isActive:
+                      coordinator.activePath.stack.last is ProductListRoute,
+                  onTap: () => coordinator.push(ProductListRoute()),
+                ),
+                _ShopNavButton(
+                  icon: Icons.shopping_cart,
+                  label: 'Cart',
+                  isActive: coordinator.activePath.stack.last is CartRoute,
+                  onTap: () => coordinator.push(CartRoute()),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+// Shop Routes
+class ShopHomeRoute extends AppRoute {
+  @override
+  Type get layout => ShopLayout;
+
+  @override
+  Uri toUri() => Uri.parse('/shop');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        const Text(
+          'Shop Home',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 16),
+        Card(
+          child: ListTile(
+            leading: const Icon(Icons.shopping_bag),
+            title: const Text('View Products'),
+            trailing: const Icon(Icons.arrow_forward),
+            onTap: () => coordinator.push(ProductListRoute()),
+          ),
+        ),
+        Card(
+          child: ListTile(
+            leading: const Icon(Icons.shopping_cart),
+            title: const Text('View Cart'),
+            trailing: const Icon(Icons.arrow_forward),
+            onTap: () => coordinator.push(CartRoute()),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class ProductListRoute extends AppRoute {
+  @override
+  Type get layout => ShopLayout;
+
+  @override
+  Uri toUri() => Uri.parse('/shop/products');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        const Text(
+          'Products',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 16),
+        _ProductCard(
+          title: 'Product 1',
+          onTap: () => coordinator.push(ProductDetailRoute(id: '1')),
+        ),
+        _ProductCard(
+          title: 'Product 2',
+          onTap: () => coordinator.push(ProductDetailRoute(id: '2')),
+        ),
+        _ProductCard(
+          title: 'Product 3',
+          onTap: () => coordinator.push(ProductDetailRoute(id: '3')),
+        ),
+      ],
+    );
+  }
+}
+
+class ProductDetailRoute extends AppRoute {
+  ProductDetailRoute({required this.id});
+
+  final String id;
+
+  @override
+  Type get layout => ShopLayout;
+
+  @override
+  Uri toUri() => Uri.parse('/shop/products/$id');
+
+  @override
+  List<Object?> get props => [id];
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Product $id')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('Product Detail $id', style: const TextStyle(fontSize: 20)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => coordinator.pop(),
+              child: const Text('Back'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class CartRoute extends AppRoute {
+  @override
+  Type get layout => ShopLayout;
+
+  @override
+  Uri toUri() => Uri.parse('/shop/cart');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        const Text(
+          'Shopping Cart',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 16),
+        const Card(
+          child: ListTile(
+            leading: Icon(Icons.shopping_cart),
+            title: Text('Item 1'),
+            subtitle: Text('\$19.99'),
+          ),
+        ),
+        const Card(
+          child: ListTile(
+            leading: Icon(Icons.shopping_cart),
+            title: Text('Item 2'),
+            subtitle: Text('\$29.99'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ============================================================================
+// Settings Module - Handles settings routes with nested navigation
+// ============================================================================
+
+class SettingsModule extends RouteModule<AppRoute> {
+  SettingsModule(super.coordinator);
+
+  // Settings module defines its own navigation path
+  late final NavigationPath<AppRoute> settingsStack = NavigationPath.createWith(
+    label: 'settings',
+    coordinator: coordinator,
+  );
+
+  @override
+  List<StackPath> get paths => [settingsStack];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      ['settings'] => GeneralSettingsRoute(),
+      ['settings', 'account'] => AccountSettingsRoute(),
+      ['settings', 'privacy'] => PrivacySettingsRoute(),
+      ['settings', 'notifications'] => NotificationsSettingsRoute(),
+      _ => null, // Not handled by this module
+    };
+  }
+
+  @override
+  void defineLayout() {
+    // Register settings layout
+    RouteLayout.defineLayout(SettingsLayout, SettingsLayout.new);
+  }
+}
+
+// Settings Layout - Provides navigation shell for settings routes
+class SettingsLayout extends AppRoute with RouteLayout<AppRoute> {
+  @override
+  NavigationPath<AppRoute> resolvePath(AppCoordinator coordinator) {
+    final settingsModule =
+        coordinator.getModule<SettingsModule>() as SettingsModule;
+    return settingsModule.settingsStack;
+  }
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(onPressed: () => coordinator.tryPop()),
+        title: const Text('Settings'),
+        backgroundColor: Colors.purple,
+      ),
+      body: Row(
+        children: [
+          // Sidebar navigation
+          Container(
+            width: 200,
+            color: Colors.grey[200],
+            child: ListView(
+              padding: const EdgeInsets.all(8),
+              children: [
+                _SettingsNavItem(
+                  icon: Icons.settings,
+                  label: 'General',
+                  route: GeneralSettingsRoute(),
+                  coordinator: coordinator,
+                ),
+                _SettingsNavItem(
+                  icon: Icons.person,
+                  label: 'Account',
+                  route: AccountSettingsRoute(),
+                  coordinator: coordinator,
+                ),
+                _SettingsNavItem(
+                  icon: Icons.lock,
+                  label: 'Privacy',
+                  route: PrivacySettingsRoute(),
+                  coordinator: coordinator,
+                ),
+                _SettingsNavItem(
+                  icon: Icons.notifications,
+                  label: 'Notifications',
+                  route: NotificationsSettingsRoute(),
+                  coordinator: coordinator,
+                ),
+              ],
+            ),
+          ),
+          // Settings content
+          Expanded(child: buildPath(coordinator)),
+        ],
+      ),
+    );
+  }
+}
+
+// Settings Routes
+class GeneralSettingsRoute extends AppRoute {
+  @override
+  Type get layout => SettingsLayout;
+
+  @override
+  Uri toUri() => Uri.parse('/settings');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        const Text(
+          'General Settings',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 16),
+        const ListTile(
+          leading: Icon(Icons.language),
+          title: Text('Language'),
+          subtitle: Text('English'),
+        ),
+        const ListTile(
+          leading: Icon(Icons.dark_mode),
+          title: Text('Theme'),
+          subtitle: Text('System'),
+        ),
+      ],
+    );
+  }
+}
+
+class AccountSettingsRoute extends AppRoute {
+  @override
+  Type get layout => SettingsLayout;
+
+  @override
+  Uri toUri() => Uri.parse('/settings/account');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        const Text(
+          'Account Settings',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 16),
+        const ListTile(
+          leading: Icon(Icons.email),
+          title: Text('Email'),
+          subtitle: Text('user@example.com'),
+        ),
+        const ListTile(
+          leading: Icon(Icons.password),
+          title: Text('Password'),
+          subtitle: Text('••••••••'),
+        ),
+      ],
+    );
+  }
+}
+
+class PrivacySettingsRoute extends AppRoute {
+  @override
+  Type get layout => SettingsLayout;
+
+  @override
+  Uri toUri() => Uri.parse('/settings/privacy');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        const Text(
+          'Privacy Settings',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 16),
+        const ListTile(
+          leading: Icon(Icons.security),
+          title: Text('Data Privacy'),
+        ),
+        const ListTile(
+          leading: Icon(Icons.location_on),
+          title: Text('Location Services'),
+        ),
+      ],
+    );
+  }
+}
+
+class NotificationsSettingsRoute extends AppRoute {
+  @override
+  Type get layout => SettingsLayout;
+
+  @override
+  Uri toUri() => Uri.parse('/settings/notifications');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        const Text(
+          'Notification Settings',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 16),
+        const ListTile(
+          leading: Icon(Icons.notifications_active),
+          title: Text('Push Notifications'),
+          trailing: Switch(value: true, onChanged: null),
+        ),
+        const ListTile(
+          leading: Icon(Icons.email),
+          title: Text('Email Notifications'),
+          trailing: Switch(value: false, onChanged: null),
+        ),
+      ],
+    );
+  }
+}
+
+// ============================================================================
+// Main Coordinator - Uses ModularCoordinator mixin
+// ============================================================================
+
+class AppCoordinator extends Coordinator<AppRoute>
+    with CoordinatorModular<AppRoute>, CoordinatorDebug {
+  @override
+  Set<RouteModule<AppRoute>> defineModules(
+    CoordinatorModular<AppRoute> coordinator,
+  ) => {
+    AuthModule(coordinator),
+    ShopModule(coordinator),
+    SettingsModule(coordinator),
+  };
+
+  @override
+  AppRoute notFoundRoute(Uri uri) => NotFoundRoute(uri: uri);
+
+  @override
+  List<AppRoute> get debugRoutes => [
+    LoginRoute(),
+    RegisterRoute(),
+    ShopHomeRoute(),
+    ProductListRoute(),
+    ProductDetailRoute(id: '1'),
+    CartRoute(),
+    GeneralSettingsRoute(),
+    AccountSettingsRoute(),
+    PrivacySettingsRoute(),
+    NotificationsSettingsRoute(),
+    NotFoundRoute(uri: Uri.parse('/not-found')),
+  ];
+}
+
+// ============================================================================
+// Not Found Route
+// ============================================================================
+
+class AppModule extends RouteModule<AppRoute> {
+  AppModule(super.coordinator);
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      ['not-found'] => NotFoundRoute(uri: uri),
+      [] => HomeRoute(),
+      _ => null,
+    };
+  }
+}
+
+class HomeRoute extends AppRoute with RouteRedirect<AppRoute> {
+  @override
+  Uri toUri() => Uri.parse('/');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) => SizedBox();
+
+  @override
+  AppRoute redirect() => LoginRoute();
+}
+
+class NotFoundRoute extends AppRoute {
+  NotFoundRoute({required this.uri});
+
+  final Uri uri;
+
+  @override
+  Uri toUri() => Uri.parse('/not-found');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Not Found')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.error_outline, size: 64, color: Colors.red),
+            const SizedBox(height: 16),
+            Text('Route not found: ${uri.path}'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () => coordinator.replace(ShopHomeRoute()),
+              child: const Text('Go to Shop'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ============================================================================
+// Helper Widgets
+// ============================================================================
+
+class _ShopNavButton extends StatelessWidget {
+  const _ShopNavButton({
+    required this.icon,
+    required this.label,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String label;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: InkWell(
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          color: isActive ? Colors.green[100] : Colors.transparent,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, color: isActive ? Colors.green[700] : Colors.grey),
+              const SizedBox(height: 4),
+              Text(
+                label,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: isActive ? Colors.green[700] : Colors.grey,
+                  fontWeight: isActive ? FontWeight.bold : FontWeight.normal,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ProductCard extends StatelessWidget {
+  const _ProductCard({required this.title, required this.onTap});
+
+  final String title;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: ListTile(
+        leading: const Icon(Icons.shopping_bag),
+        title: Text(title),
+        trailing: const Icon(Icons.arrow_forward),
+        onTap: onTap,
+      ),
+    );
+  }
+}
+
+class _SettingsNavItem extends StatelessWidget {
+  const _SettingsNavItem({
+    required this.icon,
+    required this.label,
+    required this.route,
+    required this.coordinator,
+  });
+
+  final IconData icon;
+  final String label;
+  final AppRoute route;
+  final AppCoordinator coordinator;
+
+  @override
+  Widget build(BuildContext context) {
+    final isActive =
+        coordinator.activePath.stack.last.runtimeType == route.runtimeType;
+    return ListTile(
+      leading: Icon(icon, color: isActive ? Colors.purple : Colors.grey),
+      title: Text(
+        label,
+        style: TextStyle(
+          fontWeight: isActive ? FontWeight.bold : FontWeight.normal,
+          color: isActive ? Colors.purple : Colors.black,
+        ),
+      ),
+      selected: isActive,
+      onTap: () => coordinator.push(route),
+    );
+  }
+}

--- a/packages/zenrouter/lib/src/coordinator/modular.dart
+++ b/packages/zenrouter/lib/src/coordinator/modular.dart
@@ -1,0 +1,282 @@
+import 'dart:async';
+
+import 'package:zenrouter/zenrouter.dart';
+
+/// Base class for route modules that handle a subset of application routes.
+///
+/// A [RouteModule] encapsulates a group of related routes, their navigation
+/// paths, layouts, and route parsing logic. This enables modular architecture
+/// where different parts of your application can be developed independently.
+///
+/// ## Architecture Overview
+///
+/// The modular coordinator pattern allows you to split route management across
+/// multiple modules:
+///
+/// - **RouteModule**: Handles a specific domain of routes (e.g., auth, shop, settings)
+/// - **CoordinatorModular**: Aggregates multiple modules and delegates route parsing
+/// - **Module Isolation**: Each module manages its own paths and layouts independently
+///
+/// ## Benefits
+///
+/// - **Separation of Concerns**: Each module handles its own routes and logic
+/// - **Team Collaboration**: Different teams can work on different modules
+/// - **Code Organization**: Large applications become more maintainable
+/// - **Reusability**: Modules can be reused across different applications
+///
+/// ## Creating a Route Module
+///
+/// ```dart
+/// class AuthModule extends RouteModule<AppRoute> {
+///   AuthModule(super.coordinator);
+///
+///   @override
+///   FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+///     return switch (uri.pathSegments) {
+///       ['auth', 'login'] => LoginRoute(),
+///       ['auth', 'register'] => RegisterRoute(),
+///       _ => null, // Not handled by this module
+///     };
+///   }
+///
+///   @override
+///   void defineLayout() {
+///     // Register layouts specific to auth module
+///     RouteLayout.defineLayout(AuthLayout, AuthLayout.new);
+///   }
+/// }
+/// ```
+///
+/// ## Module Responsibilities
+///
+/// Each module can:
+/// - **Parse Routes**: Implement [parseRouteFromUri] to handle specific URI patterns
+/// - **Define Paths**: Override [paths] to provide navigation paths for nested routes
+/// - **Register Layouts**: Override [defineLayout] to register layout constructors
+/// - **Register Converters**: Override [defineConverter] to register restorable converters
+///
+/// ## Route Parsing Strategy
+///
+/// When [CoordinatorModular.parseRouteFromUri] is called, it iterates through
+/// all registered modules in order. The first module that returns a non-null
+/// route wins. If all modules return null, [CoordinatorModular.notFoundRoute]
+/// is called.
+abstract class RouteModule<T extends RouteUnique> {
+  /// Creates a route module with a reference to its coordinator.
+  RouteModule(this.coordinator);
+
+  /// The coordinator that owns this module.
+  ///
+  /// Use this to access coordinator methods or other modules via
+  /// [CoordinatorModular.getModule].
+  final CoordinatorModular<T> coordinator;
+
+  /// The navigation paths managed by this module.
+  ///
+  /// Override this to provide paths for nested navigation within this module.
+  /// These paths will be automatically aggregated by [CoordinatorModular].
+  ///
+  /// **Example:**
+  /// ```dart
+  /// @override
+  /// List<StackPath> get paths => [shopPath, cartPath];
+  /// ```
+  List<StackPath> get paths => [];
+
+  /// Parses a URI and returns a route if this module handles it.
+  ///
+  /// Return `null` if this module doesn't handle the given URI. The coordinator
+  /// will continue checking other modules.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// @override
+  /// FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+  ///   return switch (uri.pathSegments) {
+  ///     ['shop'] => ShopHomeRoute(),
+  ///     ['shop', 'products', final id] => ProductRoute(id: id),
+  ///     _ => null, // Let other modules handle it
+  ///   };
+  /// }
+  /// ```
+  FutureOr<T?> parseRouteFromUri(Uri uri);
+
+  /// Defines layouts for this module.
+  ///
+  /// Override this to register layout constructors using
+  /// [RouteLayout.defineLayout]. This is called automatically during
+  /// coordinator initialization.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// @override
+  /// void defineLayout() {
+  ///   RouteLayout.defineLayout(ShopLayout, ShopLayout.new);
+  /// }
+  /// ```
+  void defineLayout() {}
+
+  /// Defines restorable converters for this module.
+  ///
+  /// Override this to register converters using
+  /// [RestorableConverter.defineConverter]. This is called automatically
+  /// during coordinator initialization.
+  void defineConverter() {}
+}
+
+/// Mixin that enables modular route management by delegating to multiple modules.
+///
+/// [CoordinatorModular] extends [Coordinator] with the ability to split route
+/// management across multiple [RouteModule] instances. This is ideal for
+/// large applications where you want to organize routes by domain or feature.
+///
+/// ## How It Works
+///
+/// 1. **Module Registration**: Implement [defineModules] to return a set of modules
+/// 2. **Route Parsing**: Routes are parsed by modules in order until one matches
+/// 3. **Path Aggregation**: All module paths are combined into the coordinator's paths
+/// 4. **Layout/Converter Delegation**: Each module's `defineLayout` and `defineConverter`
+///    are called automatically
+///
+/// ## Quick Start
+///
+/// ```dart
+/// abstract class AppRoute extends RouteTarget with RouteUnique {}
+///
+/// class AppCoordinator extends Coordinator<AppRoute>
+///     with CoordinatorModular<AppRoute> {
+///   @override
+///   Set<RouteModule<AppRoute>> defineModules(
+///     CoordinatorModular<AppRoute> coordinator,
+///   ) {
+///     return {
+///       AuthModule(coordinator),
+///       ShopModule(coordinator),
+///       SettingsModule(coordinator),
+///     };
+///   }
+///
+///   @override
+///   AppRoute notFoundRoute(Uri uri) => NotFoundRoute(uri: uri);
+/// }
+/// ```
+///
+/// ## Module Order Matters
+///
+/// Modules are checked in the order they appear in the [Set] returned by
+/// [defineModules]. The first module that returns a non-null route wins.
+/// This allows you to prioritize certain modules or handle route conflicts.
+///
+/// **Example:**
+/// ```dart
+/// @override
+/// Set<RouteModule<AppRoute>> defineModules(
+///   CoordinatorModular<AppRoute> coordinator,
+/// ) {
+///   return {
+///     AdminModule(coordinator),    // Checked first
+///     PublicModule(coordinator),  // Checked second
+///   };
+/// }
+/// ```
+///
+/// ## Accessing Modules
+///
+/// Use [getModule] to access a specific module by type. This is useful when
+/// you need module-specific functionality or paths.
+///
+/// **Example:**
+/// ```dart
+/// final shopModule = coordinator.getModule<ShopModule>();
+/// shopModule.shopPath.push(ProductRoute(id: '123'));
+/// ```
+mixin CoordinatorModular<T extends RouteUnique> on Coordinator<T> {
+  late final Map<Type, RouteModule<T>> _modules = {
+    for (final module in defineModules(this)) ...{module.runtimeType: module},
+  };
+
+  /// Defines the set of route modules for this coordinator.
+  ///
+  /// This method is called during coordinator initialization. Return a set
+  /// containing all modules that should handle routes for this coordinator.
+  ///
+  /// **Important:** The order of modules in the set determines the order
+  /// in which they are checked during route parsing. The first module that
+  /// returns a non-null route wins.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// @override
+  /// Set<RouteModule<AppRoute>> defineModules(
+  ///   CoordinatorModular<AppRoute> coordinator,
+  /// ) {
+  ///   return {
+  ///     AuthModule(coordinator),
+  ///     ShopModule(coordinator),
+  ///     SettingsModule(coordinator),
+  ///   };
+  /// }
+  /// ```
+  Set<RouteModule<T>> defineModules(
+    covariant CoordinatorModular<T> coordinator,
+  );
+
+  /// Retrieves a module by its type.
+  ///
+  /// Use this to access module-specific functionality or paths.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// final shopModule = coordinator.getModule<ShopModule>();
+  /// final productPath = shopModule.shopPath;
+  /// ```
+  ///
+  /// **Throws:** [TypeError] if the requested module type is not registered.
+  RouteModule<T> getModule<R extends RouteModule<T>>() => _modules[R] as R;
+
+  @override
+  List<StackPath<RouteTarget>> get paths => [
+    ...super.paths,
+    for (final module in _modules.values) ...module.paths,
+  ];
+
+  /// Returns a route for URIs that don't match any module.
+  ///
+  /// This is called when all modules return `null` from their
+  /// [RouteModule.parseRouteFromUri] methods. Typically, this should return
+  /// a "not found" or "404" route.
+  ///
+  /// **Example:**
+  /// ```dart
+  /// @override
+  /// AppRoute notFoundRoute(Uri uri) {
+  ///   return NotFoundRoute(uri: uri);
+  /// }
+  /// ```
+  T notFoundRoute(Uri uri);
+
+  @override
+  void defineLayout() {
+    super.defineLayout();
+    for (final module in _modules.values) {
+      module.defineLayout();
+    }
+  }
+
+  @override
+  void defineConverter() {
+    super.defineConverter();
+    for (final module in _modules.values) {
+      module.defineConverter();
+    }
+  }
+
+  @override
+  FutureOr<T> parseRouteFromUri(Uri uri) async {
+    for (final module in _modules.values) {
+      final route = await module.parseRouteFromUri(uri);
+      if (route != null) return route;
+    }
+    return notFoundRoute(uri);
+  }
+}

--- a/packages/zenrouter/lib/zenrouter.dart
+++ b/packages/zenrouter/lib/zenrouter.dart
@@ -4,6 +4,7 @@ library;
 export 'src/coordinator/base.dart';
 export 'src/coordinator/observer.dart';
 export 'src/coordinator/router.dart';
+export 'src/coordinator/modular.dart';
 
 /// Path base
 export 'src/path/base.dart';

--- a/packages/zenrouter/test/coordinator/modular_test.dart
+++ b/packages/zenrouter/test/coordinator/modular_test.dart
@@ -1,0 +1,855 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zenrouter/zenrouter.dart';
+
+// ============================================================================
+// Test Routes
+// ============================================================================
+
+abstract class AppRoute extends RouteTarget with RouteUnique {
+  @override
+  Uri toUri();
+
+  @override
+  Widget build(covariant Coordinator coordinator, BuildContext context) {
+    return Scaffold(body: Text(toString()));
+  }
+
+  @override
+  List<Object?> get props => [];
+}
+
+class HomeRoute extends AppRoute {
+  @override
+  Uri toUri() => Uri.parse('/');
+
+  @override
+  String toString() => 'HomeRoute';
+}
+
+class AuthLoginRoute extends AppRoute {
+  @override
+  Uri toUri() => Uri.parse('/auth/login');
+
+  @override
+  String toString() => 'AuthLoginRoute';
+}
+
+class AuthRegisterRoute extends AppRoute {
+  @override
+  Uri toUri() => Uri.parse('/auth/register');
+
+  @override
+  String toString() => 'AuthRegisterRoute';
+}
+
+class ShopHomeRoute extends AppRoute {
+  @override
+  Uri toUri() => Uri.parse('/shop');
+
+  @override
+  String toString() => 'ShopHomeRoute';
+}
+
+class ShopProductRoute extends AppRoute {
+  ShopProductRoute({required this.id});
+
+  final String id;
+
+  @override
+  Uri toUri() => Uri.parse('/shop/products/$id');
+
+  @override
+  String toString() => 'ShopProductRoute(id: $id)';
+
+  @override
+  List<Object?> get props => [id];
+}
+
+class SettingsRoute extends AppRoute {
+  @override
+  Uri toUri() => Uri.parse('/settings');
+
+  @override
+  String toString() => 'SettingsRoute';
+}
+
+class NotFoundRoute extends AppRoute {
+  NotFoundRoute({required this.uri});
+
+  final Uri uri;
+
+  @override
+  Uri toUri() => Uri.parse('/not-found');
+
+  @override
+  String toString() => 'NotFoundRoute(uri: $uri)';
+
+  @override
+  List<Object?> get props => [uri];
+}
+
+// ============================================================================
+// Test Modules
+// ============================================================================
+
+class AuthModule extends RouteModule<AppRoute> {
+  AuthModule(super.coordinator);
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      ['auth', 'login'] => AuthLoginRoute(),
+      ['auth', 'register'] => AuthRegisterRoute(),
+      _ => null,
+    };
+  }
+
+  @override
+  void defineLayout() {
+    // Auth module doesn't define layouts
+  }
+}
+
+class ShopModule extends RouteModule<AppRoute> {
+  ShopModule(super.coordinator);
+
+  late final NavigationPath<AppRoute> shopPath = NavigationPath.createWith(
+    label: 'shop',
+    coordinator: coordinator,
+  );
+
+  @override
+  List<StackPath> get paths => [shopPath];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      ['shop'] => ShopHomeRoute(),
+      ['shop', 'products', final id] => ShopProductRoute(id: id),
+      _ => null,
+    };
+  }
+
+  @override
+  void defineLayout() {
+    RouteLayout.defineLayout(ShopLayout, ShopLayout.new);
+  }
+}
+
+class SettingsModule extends RouteModule<AppRoute> {
+  SettingsModule(super.coordinator);
+
+  late final NavigationPath<AppRoute> settingsPath = NavigationPath.createWith(
+    label: 'settings',
+    coordinator: coordinator,
+  );
+
+  @override
+  List<StackPath> get paths => [settingsPath];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      ['settings'] => SettingsRoute(),
+      _ => null,
+    };
+  }
+
+  @override
+  void defineLayout() {
+    // Settings module doesn't define layouts
+  }
+}
+
+// Module that returns null for all routes (should be skipped)
+class EmptyModule extends RouteModule<AppRoute> {
+  EmptyModule(super.coordinator);
+
+  @override
+  List<StackPath> get paths => [];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) => null;
+
+  @override
+  void defineLayout() {}
+}
+
+// Module with async parsing
+class AsyncModule extends RouteModule<AppRoute> {
+  AsyncModule(super.coordinator, {this.delay = Duration.zero});
+
+  final Duration delay;
+
+  @override
+  List<StackPath> get paths => [];
+
+  @override
+  Future<AppRoute?> parseRouteFromUri(Uri uri) async {
+    await Future.delayed(delay);
+    return switch (uri.pathSegments) {
+      ['async'] => HomeRoute(),
+      _ => null,
+    };
+  }
+
+  @override
+  void defineLayout() {}
+}
+
+// Module that throws an error
+class ErrorModule extends RouteModule<AppRoute> {
+  ErrorModule(super.coordinator);
+
+  @override
+  List<StackPath> get paths => [];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
+    throw Exception('Module error');
+  }
+
+  @override
+  void defineLayout() {}
+}
+
+// ============================================================================
+// Test Layouts
+// ============================================================================
+
+class ShopLayout extends AppRoute with RouteLayout<AppRoute> {
+  @override
+  NavigationPath<AppRoute> resolvePath(AppCoordinator coordinator) {
+    final shopModule = coordinator.getModule<ShopModule>() as ShopModule;
+    return shopModule.shopPath;
+  }
+
+  @override
+  Widget build(covariant Coordinator coordinator, BuildContext context) {
+    return Scaffold(body: buildPath(coordinator));
+  }
+}
+
+// ============================================================================
+// Test Coordinators
+// ============================================================================
+
+class AppCoordinator extends Coordinator<AppRoute>
+    with CoordinatorModular<AppRoute> {
+  @override
+  Set<RouteModule<AppRoute>> defineModules(
+    CoordinatorModular<AppRoute> coordinator,
+  ) {
+    return {
+      AuthModule(coordinator),
+      ShopModule(coordinator),
+      SettingsModule(coordinator),
+    };
+  }
+
+  @override
+  AppRoute notFoundRoute(Uri uri) => NotFoundRoute(uri: uri);
+}
+
+class SingleModuleCoordinator extends Coordinator<AppRoute>
+    with CoordinatorModular<AppRoute> {
+  @override
+  Set<RouteModule<AppRoute>> defineModules(
+    CoordinatorModular<AppRoute> coordinator,
+  ) {
+    return {AuthModule(coordinator)};
+  }
+
+  @override
+  AppRoute notFoundRoute(Uri uri) => NotFoundRoute(uri: uri);
+}
+
+class EmptyModulesCoordinator extends Coordinator<AppRoute>
+    with CoordinatorModular<AppRoute> {
+  @override
+  Set<RouteModule<AppRoute>> defineModules(
+    CoordinatorModular<AppRoute> coordinator,
+  ) {
+    return {EmptyModule(coordinator)};
+  }
+
+  @override
+  AppRoute notFoundRoute(Uri uri) => NotFoundRoute(uri: uri);
+}
+
+class AsyncModulesCoordinator extends Coordinator<AppRoute>
+    with CoordinatorModular<AppRoute> {
+  AsyncModulesCoordinator({Duration delay = Duration.zero}) : _delay = delay;
+
+  final Duration _delay;
+
+  @override
+  Set<RouteModule<AppRoute>> defineModules(
+    CoordinatorModular<AppRoute> coordinator,
+  ) {
+    return {AsyncModule(coordinator, delay: _delay)};
+  }
+
+  @override
+  AppRoute notFoundRoute(Uri uri) => NotFoundRoute(uri: uri);
+}
+
+class ErrorModulesCoordinator extends Coordinator<AppRoute>
+    with CoordinatorModular<AppRoute> {
+  @override
+  Set<RouteModule<AppRoute>> defineModules(
+    CoordinatorModular<AppRoute> coordinator,
+  ) {
+    return {ErrorModule(coordinator)};
+  }
+
+  @override
+  AppRoute notFoundRoute(Uri uri) => NotFoundRoute(uri: uri);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+void main() {
+  group('CoordinatorModular', () {
+    group('Module Registration', () {
+      test('registers modules correctly', () {
+        final coordinator = AppCoordinator();
+
+        expect(coordinator.getModule<AuthModule>(), isA<AuthModule>());
+        expect(coordinator.getModule<ShopModule>(), isA<ShopModule>());
+        expect(coordinator.getModule<SettingsModule>(), isA<SettingsModule>());
+      });
+
+      test('throws when accessing non-existent module', () {
+        final coordinator = SingleModuleCoordinator();
+
+        expect(
+          () => coordinator.getModule<ShopModule>(),
+          throwsA(isA<TypeError>()),
+        );
+      });
+
+      test('modules are initialized with coordinator reference', () {
+        final coordinator = AppCoordinator();
+
+        final authModule = coordinator.getModule<AuthModule>();
+        expect(authModule.coordinator, equals(coordinator));
+
+        final shopModule = coordinator.getModule<ShopModule>();
+        expect(shopModule.coordinator, equals(coordinator));
+      });
+
+      test('modules are stored by type', () {
+        final coordinator = AppCoordinator();
+
+        final module1 = coordinator.getModule<AuthModule>();
+        final module2 = coordinator.getModule<AuthModule>();
+
+        expect(identical(module1, module2), isTrue);
+      });
+    });
+
+    group('Route Parsing', () {
+      test('delegates to first matching module', () async {
+        final coordinator = AppCoordinator();
+
+        final route = await coordinator.parseRouteFromUri(
+          Uri.parse('/auth/login'),
+        );
+
+        expect(route, isA<AuthLoginRoute>());
+      });
+
+      test('returns null from module when route not found in module', () async {
+        final coordinator = AppCoordinator();
+
+        final route = await coordinator.parseRouteFromUri(
+          Uri.parse('/unknown'),
+        );
+
+        expect(route, isA<NotFoundRoute>());
+      });
+
+      test('checks modules in order until match found', () async {
+        final coordinator = AppCoordinator();
+
+        // Auth module should match first
+        final authRoute = await coordinator.parseRouteFromUri(
+          Uri.parse('/auth/login'),
+        );
+        expect(authRoute, isA<AuthLoginRoute>());
+
+        // Shop module should match
+        final shopRoute = await coordinator.parseRouteFromUri(
+          Uri.parse('/shop'),
+        );
+        expect(shopRoute, isA<ShopHomeRoute>());
+
+        // Settings module should match
+        final settingsRoute = await coordinator.parseRouteFromUri(
+          Uri.parse('/settings'),
+        );
+        expect(settingsRoute, isA<SettingsRoute>());
+      });
+
+      test('handles async route parsing', () async {
+        final coordinator = AsyncModulesCoordinator();
+
+        final route = await coordinator.parseRouteFromUri(Uri.parse('/async'));
+
+        expect(route, isA<HomeRoute>());
+      });
+
+      test('handles routes with parameters', () async {
+        final coordinator = AppCoordinator();
+
+        final route = await coordinator.parseRouteFromUri(
+          Uri.parse('/shop/products/123'),
+        );
+
+        expect(route, isA<ShopProductRoute>());
+        expect((route as ShopProductRoute).id, equals('123'));
+      });
+
+      test('calls notFoundRoute when no module matches', () async {
+        final coordinator = AppCoordinator();
+
+        final route = await coordinator.parseRouteFromUri(
+          Uri.parse('/unknown/route'),
+        );
+
+        expect(route, isA<NotFoundRoute>());
+        expect((route as NotFoundRoute).uri.path, equals('/unknown/route'));
+      });
+
+      test('handles empty modules gracefully', () async {
+        final coordinator = EmptyModulesCoordinator();
+
+        final route = await coordinator.parseRouteFromUri(
+          Uri.parse('/any/route'),
+        );
+
+        expect(route, isA<NotFoundRoute>());
+      });
+
+      test('propagates errors from module parsing', () async {
+        final coordinator = ErrorModulesCoordinator();
+
+        expect(
+          () => coordinator.parseRouteFromUri(Uri.parse('/any')),
+          throwsA(isA<Exception>()),
+        );
+      });
+    });
+
+    group('Path Aggregation', () {
+      test('aggregates paths from all modules', () {
+        final coordinator = AppCoordinator();
+
+        final paths = coordinator.paths;
+
+        // Should include root path + paths from ShopModule and SettingsModule
+        expect(paths.length, greaterThan(1));
+
+        // Check that shop path exists
+        final shopModule = coordinator.getModule<ShopModule>() as ShopModule;
+        expect(paths, contains(shopModule.shopPath));
+
+        // Check that settings path exists
+        final settingsModule =
+            coordinator.getModule<SettingsModule>() as SettingsModule;
+        expect(paths, contains(settingsModule.settingsPath));
+      });
+
+      test('includes super paths', () {
+        final coordinator = AppCoordinator();
+
+        final paths = coordinator.paths;
+
+        // Should include root path
+        expect(paths, contains(coordinator.root));
+      });
+
+      test('modules without paths still work', () {
+        final coordinator = SingleModuleCoordinator();
+
+        final paths = coordinator.paths;
+
+        // Should only have root path
+        expect(paths.length, equals(1));
+        expect(paths, contains(coordinator.root));
+      });
+    });
+
+    group('Layout Definition', () {
+      test('calls defineLayout on all modules', () {
+        var authLayoutCalled = false;
+        var shopLayoutCalled = false;
+        var settingsLayoutCalled = false;
+
+        _TestLayoutCoordinator(
+          onAuthLayout: () => authLayoutCalled = true,
+          onShopLayout: () => shopLayoutCalled = true,
+          onSettingsLayout: () => settingsLayoutCalled = true,
+        );
+
+        // defineLayout is called during coordinator construction
+        expect(authLayoutCalled, isTrue);
+        expect(shopLayoutCalled, isTrue);
+        expect(settingsLayoutCalled, isTrue);
+      });
+
+      test('allows modules to register layouts', () {
+        final coordinator = AppCoordinator();
+
+        // Shop module should have registered ShopLayout
+        final shopModule = coordinator.getModule<ShopModule>() as ShopModule;
+        expect(shopModule.shopPath, isNotNull);
+      });
+    });
+
+    group('Converter Definition', () {
+      test('calls defineConverter on all modules', () {
+        var authConverterCalled = false;
+        var shopConverterCalled = false;
+        var settingsConverterCalled = false;
+
+        _TestConverterCoordinator(
+          onAuthConverter: () => authConverterCalled = true,
+          onShopConverter: () => shopConverterCalled = true,
+          onSettingsConverter: () => settingsConverterCalled = true,
+        );
+
+        // defineConverter is called during coordinator construction
+        expect(authConverterCalled, isTrue);
+        expect(shopConverterCalled, isTrue);
+        expect(settingsConverterCalled, isTrue);
+      });
+    });
+
+    group('Module Isolation', () {
+      test('modules do not interfere with each other', () async {
+        final coordinator = AppCoordinator();
+
+        // Each module should only handle its own routes
+        final authRoute = await coordinator.parseRouteFromUri(
+          Uri.parse('/auth/login'),
+        );
+        expect(authRoute, isA<AuthLoginRoute>());
+
+        final shopRoute = await coordinator.parseRouteFromUri(
+          Uri.parse('/shop'),
+        );
+        expect(shopRoute, isA<ShopHomeRoute>());
+
+        // Modules should not handle each other's routes
+        final notShopRoute = await coordinator.parseRouteFromUri(
+          Uri.parse('/auth/shop'),
+        );
+        expect(notShopRoute, isA<NotFoundRoute>());
+      });
+
+      test('modules maintain separate path instances', () {
+        final coordinator = AppCoordinator();
+
+        final shopModule = coordinator.getModule<ShopModule>() as ShopModule;
+        final settingsModule =
+            coordinator.getModule<SettingsModule>() as SettingsModule;
+
+        expect(shopModule.shopPath, isNot(equals(settingsModule.settingsPath)));
+      });
+    });
+
+    group('Edge Cases', () {
+      test('handles empty URI', () async {
+        final coordinator = AppCoordinator();
+
+        final route = await coordinator.parseRouteFromUri(Uri.parse('/'));
+
+        // Should fall through to notFoundRoute
+        expect(route, isA<NotFoundRoute>());
+      });
+
+      test('handles URI with query parameters', () async {
+        final coordinator = AppCoordinator();
+
+        final route = await coordinator.parseRouteFromUri(
+          Uri.parse('/auth/login?redirect=/home'),
+        );
+
+        expect(route, isA<AuthLoginRoute>());
+      });
+
+      test('handles URI with fragments', () async {
+        final coordinator = AppCoordinator();
+
+        final route = await coordinator.parseRouteFromUri(
+          Uri.parse('/auth/login#section'),
+        );
+
+        expect(route, isA<AuthLoginRoute>());
+      });
+
+      test('handles multiple consecutive null returns', () async {
+        final coordinator = EmptyModulesCoordinator();
+
+        final route = await coordinator.parseRouteFromUri(
+          Uri.parse('/any/route'),
+        );
+
+        expect(route, isA<NotFoundRoute>());
+      });
+    });
+
+    group('Integration Tests', () {
+      test('full flow: parse route and navigate', () async {
+        final coordinator = AppCoordinator();
+
+        // Parse route from URI
+        final route = await coordinator.parseRouteFromUri(
+          Uri.parse('/shop/products/456'),
+        );
+
+        expect(route, isA<ShopProductRoute>());
+        expect((route as ShopProductRoute).id, equals('456'));
+
+        // Push route
+        coordinator.push(route);
+        await Future.delayed(Duration.zero);
+
+        // Verify route is in stack
+        expect(coordinator.root.stack.isNotEmpty, isTrue);
+      });
+
+      test('module paths are accessible for navigation', () async {
+        final coordinator = AppCoordinator();
+
+        final shopModule = coordinator.getModule<ShopModule>() as ShopModule;
+
+        // Module paths should be accessible and functional
+        expect(shopModule.shopPath, isNotNull);
+        expect(shopModule.shopPath.debugLabel, equals('shop'));
+
+        // Should be able to push directly to module's path
+        shopModule.shopPath.push(ShopHomeRoute());
+        await Future.delayed(Duration.zero);
+        expect(shopModule.shopPath.stack.length, equals(1));
+        expect(shopModule.shopPath.stack.last, isA<ShopHomeRoute>());
+      });
+
+      test('coordinator can access module-specific functionality', () {
+        final coordinator = AppCoordinator();
+
+        final shopModule = coordinator.getModule<ShopModule>() as ShopModule;
+
+        // Module-specific paths should be accessible
+        expect(shopModule.shopPath, isNotNull);
+        expect(shopModule.shopPath.debugLabel, equals('shop'));
+      });
+    });
+  });
+
+  group('RouteModule', () {
+    test('can be instantiated with coordinator', () {
+      final coordinator = AppCoordinator();
+      final module = AuthModule(coordinator);
+
+      expect(module.coordinator, equals(coordinator));
+    });
+
+    test('default paths returns empty list', () {
+      final coordinator = AppCoordinator();
+      final module = AuthModule(coordinator);
+
+      expect(module.paths, isEmpty);
+    });
+
+    test('default defineLayout does nothing', () {
+      final coordinator = AppCoordinator();
+      final module = AuthModule(coordinator);
+
+      // Should not throw
+      expect(() => module.defineLayout(), returnsNormally);
+    });
+
+    test('default defineConverter does nothing', () {
+      final coordinator = AppCoordinator();
+      final module = AuthModule(coordinator);
+
+      // Should not throw
+      expect(() => module.defineConverter(), returnsNormally);
+    });
+
+    test('can override paths getter', () {
+      final coordinator = AppCoordinator();
+      final shopModule = coordinator.getModule<ShopModule>() as ShopModule;
+
+      expect(shopModule.paths.length, equals(1));
+      expect(shopModule.paths.first, equals(shopModule.shopPath));
+    });
+
+    test('can override defineLayout', () {
+      final coordinator = AppCoordinator();
+      final shopModule = coordinator.getModule<ShopModule>() as ShopModule;
+
+      // Shop module defines layout, should not throw
+      expect(() => shopModule.defineLayout(), returnsNormally);
+    });
+  });
+}
+
+// ============================================================================
+// Test Helper Coordinators
+// ============================================================================
+
+class _TestLayoutCoordinator extends Coordinator<AppRoute>
+    with CoordinatorModular<AppRoute> {
+  _TestLayoutCoordinator({
+    required this.onAuthLayout,
+    required this.onShopLayout,
+    required this.onSettingsLayout,
+  });
+
+  final VoidCallback onAuthLayout;
+  final VoidCallback onShopLayout;
+  final VoidCallback onSettingsLayout;
+
+  @override
+  Set<RouteModule<AppRoute>> defineModules(
+    CoordinatorModular<AppRoute> coordinator,
+  ) {
+    return {
+      _TestAuthModule(coordinator, onLayout: onAuthLayout),
+      _TestShopModule(coordinator, onLayout: onShopLayout),
+      _TestSettingsModule(coordinator, onLayout: onSettingsLayout),
+    };
+  }
+
+  @override
+  AppRoute notFoundRoute(Uri uri) => NotFoundRoute(uri: uri);
+}
+
+class _TestAuthModule extends RouteModule<AppRoute> {
+  _TestAuthModule(super.coordinator, {required this.onLayout});
+
+  final VoidCallback onLayout;
+
+  @override
+  List<StackPath> get paths => [];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) => null;
+
+  @override
+  void defineLayout() => onLayout();
+}
+
+class _TestShopModule extends RouteModule<AppRoute> {
+  _TestShopModule(super.coordinator, {required this.onLayout});
+
+  final VoidCallback onLayout;
+
+  @override
+  List<StackPath> get paths => [];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) => null;
+
+  @override
+  void defineLayout() => onLayout();
+}
+
+class _TestSettingsModule extends RouteModule<AppRoute> {
+  _TestSettingsModule(super.coordinator, {required this.onLayout});
+
+  final VoidCallback onLayout;
+
+  @override
+  List<StackPath> get paths => [];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) => null;
+
+  @override
+  void defineLayout() => onLayout();
+}
+
+class _TestConverterCoordinator extends Coordinator<AppRoute>
+    with CoordinatorModular<AppRoute> {
+  _TestConverterCoordinator({
+    required this.onAuthConverter,
+    required this.onShopConverter,
+    required this.onSettingsConverter,
+  });
+
+  final VoidCallback onAuthConverter;
+  final VoidCallback onShopConverter;
+  final VoidCallback onSettingsConverter;
+
+  @override
+  Set<RouteModule<AppRoute>> defineModules(
+    CoordinatorModular<AppRoute> coordinator,
+  ) {
+    return {
+      _TestAuthConverterModule(coordinator, onConverter: onAuthConverter),
+      _TestShopConverterModule(coordinator, onConverter: onShopConverter),
+      _TestSettingsConverterModule(
+        coordinator,
+        onConverter: onSettingsConverter,
+      ),
+    };
+  }
+
+  @override
+  AppRoute notFoundRoute(Uri uri) => NotFoundRoute(uri: uri);
+}
+
+class _TestAuthConverterModule extends RouteModule<AppRoute> {
+  _TestAuthConverterModule(super.coordinator, {required this.onConverter});
+
+  final VoidCallback onConverter;
+
+  @override
+  List<StackPath> get paths => [];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) => null;
+
+  @override
+  void defineConverter() => onConverter();
+}
+
+class _TestShopConverterModule extends RouteModule<AppRoute> {
+  _TestShopConverterModule(super.coordinator, {required this.onConverter});
+
+  final VoidCallback onConverter;
+
+  @override
+  List<StackPath> get paths => [];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) => null;
+
+  @override
+  void defineConverter() => onConverter();
+}
+
+class _TestSettingsConverterModule extends RouteModule<AppRoute> {
+  _TestSettingsConverterModule(super.coordinator, {required this.onConverter});
+
+  final VoidCallback onConverter;
+
+  @override
+  List<StackPath> get paths => [];
+
+  @override
+  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) => null;
+
+  @override
+  void defineConverter() => onConverter();
+}


### PR DESCRIPTION
# 🧩 Feature: Modular Coordinator

## Summary

Adds `CoordinatorModular` mixin and `RouteModule` base class to enable modular route management. This allows large applications to split route handling across multiple independent modules, improving code organization, team collaboration, and maintainability.

## 🎯 Motivation

As applications grow, managing all routes in a single `parseRouteFromUri` method becomes unwieldy. The modular coordinator pattern addresses this by:

- **Organizing routes by domain** (auth, shop, settings, etc.)
- **Enabling team collaboration** (different teams work on different modules)
- **Improving maintainability** (each module is self-contained)
- **Supporting code reuse** (modules can be shared across apps)

## 📊 Architecture Flow

### Route Parsing Flow

```mermaid
graph TD
    A[URI Request] --> B[CoordinatorModular.parseRouteFromUri]
    B --> C{Iterate Modules}
    C --> D[Module 1: AuthModule]
    D --> E{Returns Route?}
    E -->|null| F[Module 2: ShopModule]
    E -->|Route| G[Return Route ✅]
    F --> H{Returns Route?}
    H -->|null| I[Module 3: SettingsModule]
    H -->|Route| G
    I --> J{Returns Route?}
    J -->|null| K[notFoundRoute]
    J -->|Route| G
    K --> L[Return NotFoundRoute]
```

### Module Registration Flow

```mermaid
graph LR
    A[Coordinator Created] --> B[defineModules Called]
    B --> C[Create AuthModule]
    B --> D[Create ShopModule]
    B --> E[Create SettingsModule]
    C --> F[Store in _modules Map]
    D --> F
    E --> F
    F --> G[Call defineLayout on each]
    F --> H[Call defineConverter on each]
    F --> I[Aggregate paths from each]
```

### Path Aggregation Flow

```mermaid
graph TD
    A[CoordinatorModular.paths] --> B[super.paths<br/>root path]
    A --> C[Module 1 paths]
    A --> D[Module 2 paths]
    A --> E[Module 3 paths]
    C --> F[Combined Paths List]
    D --> F
    E --> F
    B --> F
```

## 🔑 Key Features

### 1. Route Module Pattern

Each module handles a specific domain:

```dart
class AuthModule extends RouteModule<AppRoute> {
  AuthModule(super.coordinator);

  @override
  FutureOr<AppRoute?> parseRouteFromUri(Uri uri) {
    return switch (uri.pathSegments) {
      ['auth', 'login'] => LoginRoute(),
      ['auth', 'register'] => RegisterRoute(),
      _ => null, // Not handled by this module
    };
  }
}
```

### 2. Modular Coordinator

Aggregates multiple modules:

```dart
class AppCoordinator extends Coordinator<AppRoute>
    with CoordinatorModular<AppRoute> {
  
  @override
  Set<RouteModule<AppRoute>> defineModules(
    CoordinatorModular<AppRoute> coordinator,
  ) {
    return {
      AuthModule(coordinator),
      ShopModule(coordinator),
      SettingsModule(coordinator),
    };
  }

  @override
  AppRoute notFoundRoute(Uri uri) => NotFoundRoute(uri: uri);
}
```

### 3. Automatic Path Aggregation

All module paths are automatically combined:

```dart
// Module paths are automatically included
coordinator.paths // [root, shopPath, settingsPath, ...]
```

### 4. Layout & Converter Delegation

Each module can register its own layouts and converters:

```dart
@override
void defineLayout() {
  RouteLayout.defineLayout(ShopLayout, ShopLayout.new);
}
```

## 📝 Usage Example

### Before (Monolithic)

```dart
class AppCoordinator extends Coordinator<AppRoute> {
  @override
  AppRoute parseRouteFromUri(Uri uri) {
    // All routes in one method - becomes unwieldy
    return switch (uri.pathSegments) {
      ['auth', 'login'] => LoginRoute(),
      ['auth', 'register'] => RegisterRoute(),
      ['shop'] => ShopHomeRoute(),
      ['shop', 'products', final id] => ProductRoute(id: id),
      ['settings'] => SettingsRoute(),
      ['settings', 'account'] => AccountSettingsRoute(),
      // ... 50+ more routes
      _ => NotFoundRoute(uri: uri),
    };
  }
}
```

### After (Modular)

```dart
// AuthModule handles auth routes
class AuthModule extends RouteModule<AppRoute> {
  // ... handles /auth/* routes
}

// ShopModule handles shop routes
class ShopModule extends RouteModule<AppRoute> {
  // ... handles /shop/* routes
}

// SettingsModule handles settings routes
class SettingsModule extends RouteModule<AppRoute> {
  // ... handles /settings/* routes
}

// Coordinator aggregates modules
class AppCoordinator extends Coordinator<AppRoute>
    with CoordinatorModular<AppRoute> {
  @override
  Set<RouteModule<AppRoute>> defineModules(...) {
    return {AuthModule(...), ShopModule(...), SettingsModule(...)};
  }
}
```

## 🧪 Testing

Comprehensive test suite with **33 tests** covering:

- ✅ Module registration and retrieval
- ✅ Route parsing delegation
- ✅ Path aggregation
- ✅ Layout and converter delegation
- ✅ Module isolation
- ✅ Edge cases (empty URIs, query params, fragments)
- ✅ Integration tests
- ✅ Error handling

**Test file:** `test/coordinator/modular_test.dart`

## 📚 Documentation

- **Guide:** `doc/guides/coordinator-modular.md` - Complete usage guide
- **API Docs:** Inline documentation in `lib/src/coordinator/modular.dart`
- **Example:** `example/lib/main_modular.dart` - Full working example

## 🎨 Example App

A complete example demonstrating:

- ✅ Three modules (Auth, Shop, Settings)
- ✅ Module-specific layouts
- ✅ Nested navigation within modules
- ✅ Module path management

**Location:** `packages/zenrouter/example/lib/main_modular.dart`

## 🔄 Migration Path

Existing coordinators can be migrated incrementally:

1. **Start small:** Extract one domain into a module
2. **Test:** Ensure routes still work
3. **Repeat:** Extract more domains over time
4. **Complete:** All routes moved to modules

No breaking changes - existing coordinators continue to work.

## 📋 Checklist

- [x] Implementation complete
- [x] Comprehensive test suite (33 tests)
- [x] Documentation guide created
- [x] Example app created
- [x] API documentation added
- [x] Exported in `zenrouter.dart`
- [x] All tests passing
- [x] No breaking changes

## 🔗 Related

- **Issue:** [Link to related issue if applicable]
- **Documentation:** [doc/guides/coordinator-modular.md](doc/guides/coordinator-modular.md)
- **Example:** [example/lib/main_modular.dart](example/lib/main_modular.dart)

---

## Visual Flow Diagram (ASCII)

```
┌─────────────────────────────────────────────────────────────┐
│                    Route Parsing Flow                       │
└─────────────────────────────────────────────────────────────┘

URI: /shop/products/123
    │
    ▼
┌─────────────────────┐
│ CoordinatorModular  │
│  parseRouteFromUri  │
└─────────────────────┘
    │
    ├─► Module 1: AuthModule
    │   └─► parseRouteFromUri('/shop/products/123')
    │       └─► Returns: null ❌
    │
    ├─► Module 2: ShopModule
    │   └─► parseRouteFromUri('/shop/products/123')
    │       └─► Returns: ProductRoute(id: '123') ✅
    │
    └─► Return ProductRoute immediately
        (doesn't check remaining modules)

┌─────────────────────────────────────────────────────────────┐
│                  Module Initialization                      │
└─────────────────────────────────────────────────────────────┘

Coordinator Created
    │
    ▼
defineModules() called
    │
    ├─► Create AuthModule
    ├─► Create ShopModule
    └─► Create SettingsModule
    │
    ▼
Store in _modules Map<Type, RouteModule>
    │
    ├─► Call defineLayout() on each module
    ├─► Call defineConverter() on each module
    └─► Aggregate paths from each module
    │
    ▼
Coordinator ready ✅

┌─────────────────────────────────────────────────────────────┐
│                    Path Aggregation                         │
└─────────────────────────────────────────────────────────────┘

coordinator.paths
    │
    ├─► super.paths
    │   └─► [root]
    │
    ├─► AuthModule.paths
    │   └─► [] (no paths)
    │
    ├─► ShopModule.paths
    │   └─► [shopPath]
    │
    └─► SettingsModule.paths
        └─► [settingsPath]
    │
    ▼
Final paths: [root, shopPath, settingsPath]
```

---

## 🚀 Benefits

| Aspect | Before | After |
|--------|--------|-------|
| **Code Organization** | All routes in one file | Routes organized by module |
| **Team Collaboration** | Requires coordination | Teams work independently |
| **Maintainability** | Large parseRouteFromUri | Small, focused modules |
| **Scalability** | Becomes unwieldy | Scales with modules |
| **Reusability** | Routes tied to app | Modules reusable |

---

**Ready for review!** 🎉
