### PR TITLE
feat(zenrouter_devtools): adding Coordinator awareness, a navigate method, and improving debug overlay UI.

### DIFF
--- a/packages/zenrouter/pubspec.yaml
+++ b/packages/zenrouter/pubspec.yaml
@@ -2,7 +2,7 @@ name: zenrouter
 description: >-
   A powerful Flutter router with deep linking, web support, type-safe routing,
   guards, redirects, and zero boilerplate.
-version: 1.1.0
+version: 1.2.0
 
 repository: https://github.com/definev/zenrouter
 homepage: https://github.com/definev/zenrouter/tree/main/packages/zenrouter

--- a/packages/zenrouter_devtools/CHANGELOG.md
+++ b/packages/zenrouter_devtools/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0
+- **BREAKING**: Update dependency to `zenrouter: ^1.2.0`
+- **Feat**: New sub module `Coordinator` aware in `Inspect Tab 
+- **Feat**: Add `navigate` method
+- **Fix**: Fix Increase close button size in `DebugOverlay`
+
 ## 1.0.0
 - **BREAKING**: Update dependency to `zenrouter: ^1.0.0`
 - Support for new `RouteRedirectRule` feature

--- a/packages/zenrouter_devtools/example/pubspec.lock
+++ b/packages/zenrouter_devtools/example/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -111,26 +111,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   vector_math:
     dependency: transitive
     description:
@@ -225,5 +225,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/zenrouter_devtools/lib/src/debug_overlay.dart
+++ b/packages/zenrouter_devtools/lib/src/debug_overlay.dart
@@ -62,46 +62,52 @@ class _DebugOverlayState<T extends RouteUnique> extends State<DebugOverlay<T>> {
     return Align(
       alignment: Alignment.bottomRight,
       child: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(DebugTheme.spacingLg),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              ListenableBuilder(
-                listenable: _uriController,
-                builder:
-                    (context, child) => Container(
-                      decoration: BoxDecoration(
-                        color: Color(0xFF000000).withValues(alpha: 0.6),
-                        borderRadius: BorderRadius.circular(
-                          DebugTheme.radiusFull,
-                        ),
-                      ),
-                      height: 40,
-                      margin: const EdgeInsets.only(
-                        right: DebugTheme.spacingXs,
-                      ),
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: DebugTheme.spacingMd,
-                      ),
-                      child: Center(
-                        child: Text(
-                          _uriController.text,
-                          style: const TextStyle(
-                            color: Color(0xFFFFFFFF),
-                            decoration: TextDecoration.none,
-                            fontWeight: FontWeight.normal,
-                            fontSize: DebugTheme.fontSizeMd,
+        child: IntrinsicWidth(
+          child: Padding(
+            padding: const EdgeInsets.all(DebugTheme.spacingLg),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                ListenableBuilder(
+                  listenable: _uriController,
+                  builder:
+                      (context, child) => Expanded(
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: Color(0xFF000000).withValues(alpha: 0.6),
+                            borderRadius: BorderRadius.circular(
+                              DebugTheme.radiusFull,
+                            ),
+                          ),
+                          height: 40,
+                          margin: const EdgeInsets.only(
+                            right: DebugTheme.spacingXs,
+                          ),
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: DebugTheme.spacingMd,
+                          ),
+                          child: Center(
+                            child: Text(
+                              _uriController.text,
+                              style: const TextStyle(
+                                color: Color(0xFFFFFFFF),
+                                decoration: TextDecoration.none,
+                                fontWeight: FontWeight.normal,
+                                fontSize: DebugTheme.fontSizeMd,
+                              ),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-              ),
-              _DebugFab(
-                problems: widget.coordinator.problems,
-                onTap: widget.coordinator.toggleDebugOverlay,
-              ),
-            ],
+                ),
+                _DebugFab(
+                  problems: widget.coordinator.problems,
+                  onTap: widget.coordinator.toggleDebugOverlay,
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/packages/zenrouter_devtools/pubspec.yaml
+++ b/packages/zenrouter_devtools/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zenrouter_devtools
 description: "Deeplink, Inspection, and Debugging Devtools for ZenRouter"
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/definev/zenrouter/tree/main/packages/zenrouter_devtools
 
 environment:
@@ -20,7 +20,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   flutter:
     sdk: flutter
-  zenrouter: ^1.0.0
+  zenrouter: ^1.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request updates `zenrouter_devtools` to version 1.1.0, introducing several new features, improvements to the debug overlay UI, and updating dependencies for compatibility. The most notable changes are the addition of coordinator awareness, a new navigation method, and enhancements to the debug overlay for better usability.

Dependency and version updates:

* Updated `zenrouter_devtools` to version `1.1.0` and its dependency on `zenrouter` to `^1.2.0` for compatibility with the latest features and breaking changes. (`[[1]](diffhunk://#diff-9e26b9183a1f5dd31223ea86843a5311de8de3e033494fe28ec958fe6c2a12a0L3-R3)`, `[[2]](diffhunk://#diff-9e26b9183a1f5dd31223ea86843a5311de8de3e033494fe28ec958fe6c2a12a0L23-R23)`, `[[3]](diffhunk://#diff-83d6257d197cd3db3b11776af0e8f7979cd57974ebe2fffe430345ef91ff9836L5-R5)`)

New features:

* Added coordinator awareness in the Inspect Tab, allowing for more advanced inspection and debugging of coordinated routing flows. (`[packages/zenrouter_devtools/CHANGELOG.mdR1-R6](diffhunk://#diff-7381b122a076cd7a9bf539609758f70ff85c5e34cbf88b17b30c78ab92ddd153R1-R6)`)
* Introduced a new `navigate` method to improve navigation capabilities within the devtools. (`[packages/zenrouter_devtools/CHANGELOG.mdR1-R6](diffhunk://#diff-7381b122a076cd7a9bf539609758f70ff85c5e34cbf88b17b30c78ab92ddd153R1-R6)`)

Debug overlay improvements:

* Increased the close button size in the debug overlay for better accessibility. (`[packages/zenrouter_devtools/CHANGELOG.mdR1-R6](diffhunk://#diff-7381b122a076cd7a9bf539609758f70ff85c5e34cbf88b17b30c78ab92ddd153R1-R6)`)
* Enhanced the debug overlay UI by wrapping the content in `IntrinsicWidth` for layout stability, using `Expanded` for responsive containers, and adding ellipsis and max lines to text for improved readability. (`[[1]](diffhunk://#diff-b2c5977c23f770efc57398cd9c96a21f50c578703a172bc55364e75a0350dd34R65)`, `[[2]](diffhunk://#diff-b2c5977c23f770efc57398cd9c96a21f50c578703a172bc55364e75a0350dd34L73-R75)`, `[[3]](diffhunk://#diff-b2c5977c23f770efc57398cd9c96a21f50c578703a172bc55364e75a0350dd34R98-R100)`, `[[4]](diffhunk://#diff-b2c5977c23f770efc57398cd9c96a21f50c578703a172bc55364e75a0350dd34R113)`)…