### PR TITLE
feat: Default to show debug_coordinator in debug mode

### DIFF
--- a/packages/zenrouter_devtools/README.md
+++ b/packages/zenrouter_devtools/README.md
@@ -46,6 +46,7 @@ You can customize the devtools by overriding properties in your coordinator:
 
 ```dart
 class AppCoordinator extends Coordinator<AppRoute> with CoordinatorDebug<AppRoute> {
+
   // Only enable in debug mode (default)
   @override
   bool get debugEnabled => kDebugMode;

--- a/packages/zenrouter_devtools/README.md
+++ b/packages/zenrouter_devtools/README.md
@@ -24,7 +24,7 @@ A powerful debugging tool for [ZenRouter](https://pub.dev/packages/zenrouter), p
 Add `zenrouter_devtools` to your `pubspec.yaml`:
 
 ```yaml
-dev_dependencies:
+dependencies:
   zenrouter_devtools: ^latest_version
 ```
 
@@ -46,8 +46,7 @@ You can customize the devtools by overriding properties in your coordinator:
 
 ```dart
 class AppCoordinator extends Coordinator<AppRoute> with CoordinatorDebug<AppRoute> {
-  
-  // Only enable in debug mode
+  // Only enable in debug mode (default)
   @override
   bool get debugEnabled => kDebugMode;
 

--- a/packages/zenrouter_devtools/lib/src/coordinator_debug.dart
+++ b/packages/zenrouter_devtools/lib/src/coordinator_debug.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:zenrouter/zenrouter.dart';
 
@@ -40,11 +41,7 @@ mixin CoordinatorDebug<T extends RouteUnique> on Coordinator<T> {
   ///
   /// Defaults to `kDebugMode`. Override this to conditionally enable/disable
   /// the debug overlay (e.g., only in debug mode).
-  bool get debugEnabled =>
-      // kReleaseMode
-      !const bool.fromEnvironment('dart.vm.product') &&
-      // kProfileMode
-      !const bool.fromEnvironment('dart.vm.profile');
+  bool get debugEnabled => kDebugMode;
 
   /// Override this to provide a list of routes that can be quickly pushed
   /// from the debug overlay.

--- a/packages/zenrouter_devtools/lib/src/coordinator_debug.dart
+++ b/packages/zenrouter_devtools/lib/src/coordinator_debug.dart
@@ -38,9 +38,13 @@ mixin CoordinatorDebug<T extends RouteUnique> on Coordinator<T> {
 
   /// Toggle debug overlay visibility.
   ///
-  /// Defaults to `true`. Override this to conditionally enable/disable
+  /// Defaults to `kDebugMode`. Override this to conditionally enable/disable
   /// the debug overlay (e.g., only in debug mode).
-  bool get debugEnabled => true;
+  bool get debugEnabled =>
+      // kReleaseMode
+      !const bool.fromEnvironment('dart.vm.product') &&
+      // kProfileMode
+      !const bool.fromEnvironment('dart.vm.profile');
 
   /// Override this to provide a list of routes that can be quickly pushed
   /// from the debug overlay.


### PR DESCRIPTION
I update the `README.md`, since `DebugCoordinator` is packaged and shipped with the app, it _should_ be included in the `dependencies` list.