### PR TITLE
feat: add RouteGuardRule for composable pop guards

### DIFF
--- a/.skills/DOCUMENTATION.md
+++ b/.skills/DOCUMENTATION.md
@@ -105,6 +105,7 @@ ReturnType methodName(Parameters);
 | `lib/src/mixin/deeplink.dart` | RouteDeepLink and DeeplinkStrategy |
 | `lib/src/mixin/redirect.dart` | RouteRedirect for route redirection |
 | `lib/src/mixin/redirect_rule.dart` | RedirectRule and RedirectResult for composable redirects |
+| `lib/src/mixin/guard_rule.dart` | GuardRule and RouteGuardRule for composable pop guards |
 | `lib/src/mixin/identity.dart` | RouteIdentity for route identification |
 | `lib/src/mixin/target.dart` | RouteTarget base class with lifecycle |
 

--- a/packages/zenrouter/README.md
+++ b/packages/zenrouter/README.md
@@ -424,7 +424,7 @@ class MyApp extends StatelessWidget {
 > [!IMPORTANT]
 > State restoration requires routes to be parsed **synchronously** during startup. If `parseRouteFromUri` is asynchronous, override `parseRouteFromUriSync` to provide a synchronous fallback.
 
-→ [Full coordinator example](https://github.com/definev/zenrouter/blob/main/packages/zenrouter/example/lib/main_coordinator.dart) · [Modular coordinator example](https://github.com/definev/zenrouter/blob/main/packages/zenrouter/example/lib/main_coordinator_module.dart) · [State restoration example](https://github.com/definev/zenrouter/blob/main/packages/zenrouter/example/lib/main_restoration.dart)
+→ [Full coordinator example](https://github.com/definev/zenrouter/blob/main/packages/zenrouter/example/lib/main_coordinator.dart) · [Modular coordinator example](https://github.com/definev/zenrouter/blob/main/packages/zenrouter/example/lib/main_coordinator_module.dart) · [Guard rules example](https://github.com/definev/zenrouter/blob/main/packages/zenrouter/example/lib/main_guard_rules.dart) · [State restoration example](https://github.com/definev/zenrouter/blob/main/packages/zenrouter/example/lib/main_restoration.dart)
 
 ---
 

--- a/packages/zenrouter/doc/api/mixins.md
+++ b/packages/zenrouter/doc/api/mixins.md
@@ -23,6 +23,7 @@ Each mixin adds specific capabilities:
 - **RouteLayout** - Creates navigation layout for nested routes
 - **RouteTransition** - Custom page transitions
 - **RouteGuard** - Prevents unwanted navigation
+- **RouteGuardRule** - Composable pop-guard rules (works with RouteGuard)
 - **RouteRedirect** - Redirects to different routes
 - **RouteRedirectRule** - Composable redirect rules (works with RouteRedirect)
 - **RouteDeepLink** - Custom deep link handling
@@ -38,7 +39,9 @@ Which mixins do I need?
 │  └─ No → Continue
 │
 ├─ Prevent navigation (unsaved changes)?
-│  ├─ Yes → Add RouteGuard ✓
+│  ├─ Need reusable/composable rules?
+│  │  ├─ Yes → Add RouteGuardRule ✓
+│  │  └─ No → Add RouteGuard ✓
 │  └─ No → Continue
 │
 ├─ Conditional routing (auth, permissions)?
@@ -279,6 +282,12 @@ Use this mixin when you need to protect forms with unsaved changes, prevent inte
 
 ```dart
 mixin RouteGuard on RouteTarget {
+  // PopScope.canPop — true = free pop, false = intercept then popGuard (default false)
+  bool get canPop;
+
+  // ListenableMixin so PopScope rebuilds when canPop changes
+  ListenableMixin? get canPopListenable;
+
   // Return true to allow pop, false to prevent
   FutureOr<bool> popGuard();
 
@@ -288,24 +297,26 @@ mixin RouteGuard on RouteTarget {
 }
 ```
 
-#### Example: Unsaved Changes Warning
+#### Example: Reactive Unsaved Changes
 
 ```dart
 class EditFormRoute extends RouteTarget with RouteUnique, RouteGuard {
-  bool hasUnsavedChanges = false;
-  
+  final dirty = ValueNotifier(false);
+
+  @override
+  ListenableMixin? get canPopListenable => dirty.toListenableMixin();
+
+  @override
+  bool get canPop => !dirty.value; // free back when clean
+
   @override
   Future<bool> popGuard() async {
-    if (!hasUnsavedChanges) return true; // No unsaved changes, allow navigation
-    
-    // Ask user to confirm discarding changes
+    // Only reached when dirty (canPop was false)
     final shouldPop = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Unsaved Changes'),
-        content: const Text(
-          'You have unsaved changes. Discard them?',
-        ),
+        content: const Text('You have unsaved changes. Discard them?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
@@ -319,13 +330,12 @@ class EditFormRoute extends RouteTarget with RouteUnique, RouteGuard {
         ],
       ),
     );
-    
     return shouldPop ?? false;
   }
-  
+
   @override
   Uri toUri() => Uri.parse('/edit');
-  
+
   @override
   Widget build(Coordinator coordinator, BuildContext context) {
     return Scaffold(
@@ -340,7 +350,7 @@ class EditFormRoute extends RouteTarget with RouteUnique, RouteGuard {
         ),
       ),
       body: TextField(
-        onChanged: (value) => hasUnsavedChanges = true,
+        onChanged: (value) => dirty.value = true,
         decoration: const InputDecoration(
           hintText: 'Start typing...',
         ),
@@ -387,6 +397,117 @@ class UploadRoute extends RouteTarget with RouteGuard {
   }
 }
 ```
+
+---
+
+### RouteGuardRule
+
+Enables composable, reusable pop-guard logic by chaining multiple `GuardRule` instances together. This mixin implements `RouteGuard` and provides a rule-based approach to leave confirmation, making it easy to create reusable unsaved-changes, permission, and logging rules.
+
+**Benefits over direct `RouteGuard` implementation:**
+- **Reusable**: One rule can be used for multiple routes
+- **Composable**: Chain multiple rules together (unsaved changes → confirm leave)
+- **Testable**: Test each rule independently
+- **Maintainable**: Centralized guard logic, easy to modify
+
+**Use when:**
+- You need the same pop-guard logic across multiple routes
+- You want to combine multiple leave checks
+- You prefer a rule-based architecture
+- You want to test guard logic independently
+
+**Not needed when:**
+- You have simple, route-specific pop-guard logic
+- You only need a single guard check
+
+#### API
+
+```dart
+// Base class for creating guard rules
+abstract class GuardRule<T extends RouteTarget> {
+  bool canPop(covariant T route); // default true
+  ListenableMixin? canPopListenable(covariant T route);
+  FutureOr<bool?> guard(
+    covariant Coordinator coordinator,
+    covariant T route,
+  );
+}
+
+// Mixin for routes
+mixin RouteGuardRule<T extends RouteTarget> on RouteTarget
+    implements RouteGuard {
+  List<GuardRule> get guardRules;
+
+  // canPop / canPopListenable derived from rules
+  // Automatically implements RouteGuard.popGuardWith()
+}
+```
+
+| `bool?` | Meaning |
+|---------|---------|
+| `null` | Continue to next rule |
+| `true` | Allow pop; stop chain |
+| `false` | Block pop; stop chain |
+
+If every rule returns `null` (or the list is empty), the pop is allowed.
+
+#### Example: Unsaved Changes Rule
+
+```dart
+class UnsavedChangesRule extends GuardRule<AppRoute> {
+  @override
+  bool canPop(AppRoute route) =>
+      route is! EditableRoute || !route.hasUnsavedChanges;
+
+  @override
+  ListenableMixin? canPopListenable(AppRoute route) =>
+      route is EditableRoute ? route.dirty.toListenableMixin() : null;
+
+  @override
+  FutureOr<bool?> guard(
+    Coordinator coordinator,
+    AppRoute route,
+  ) async {
+    if (route is! EditableRoute || !route.hasUnsavedChanges) {
+      return null; // Not applicable → next rule
+    }
+    final shouldDiscard = await showDialog<bool>(/* ... */);
+    return shouldDiscard ?? false;
+  }
+}
+
+class EditorRoute extends AppRoute
+    with EditableRoute, RouteGuardRule<AppRoute> {
+  @override
+  List<GuardRule> get guardRules => [
+    UnsavedChangesRule(),
+    ConfirmLeaveRule(), // runs only if unsaved rule returned null
+  ];
+
+  @override
+  Uri toUri() => Uri.parse('/editor');
+
+  @override
+  Widget build(AppCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Editor')),
+      body: TextField(onChanged: (_) => markDirty()),
+    );
+  }
+}
+```
+
+For a full multi-rule walkthrough (upload + unsaved + audit), see
+[Composable Route Guard Rules](../recipes/route-guard-rules.md).
+
+#### When to Use RouteGuardRule vs RouteGuard
+
+| Use Case | Use RouteGuard | Use RouteGuardRule |
+|----------|----------------|-------------------|
+| Single, route-specific check | ✓ | |
+| Same logic on many routes | | ✓ |
+| Chain multiple leave checks | | ✓ |
+| Independent unit tests per rule | | ✓ |
 
 ---
 

--- a/packages/zenrouter/doc/recipes/README.md
+++ b/packages/zenrouter/doc/recipes/README.md
@@ -30,6 +30,17 @@ Protect routes, redirect unauthenticated users, and preserve intended destinatio
 
 ---
 
+### [Composable Route Guard Rules](route-guard-rules.md)
+Block leaving a screen with reusable rules — unsaved edits, uploads, confirm dialogs — plus reactive `canPop`.
+
+Runnable: [`example/lib/main_guard_rules.dart`](../../example/lib/main_guard_rules.dart) (`flutter run -t lib/main_guard_rules.dart`)
+
+**Topics**: RouteGuardRule, GuardRule, canPop, ListenableMixin, PopScope  
+**Paradigm**: Coordinator  
+**Difficulty**: ⭐⭐ Moderate
+
+---
+
 ### [Bottom Navigation with Persistent State](bottom-navigation.md)
 Create tab bars where each tab maintains its own navigation stack independently.
 
@@ -91,6 +102,7 @@ Configure hash vs. path-based URLs, server setup, and deployment strategies.
 |----------|--------|
 | Tab bar with persistent tabs | [Bottom Navigation](bottom-navigation.md) |
 | Login with protected routes | [Authentication Flow](authentication-flow.md) |
+| Unsaved changes / confirm leave | [Composable Route Guard Rules](route-guard-rules.md) |
 | Invalid URL handling | [404 Handling](404-handling.md) |
 | Sidebar + content layout | [Route Layout](../guides/route-layout.md) |
 | Custom animations | [Route Transitions](route-transitions.md) |
@@ -112,7 +124,7 @@ Configure hash vs. path-based URLs, server setup, and deployment strategies.
 | Level | Recipes |
 |-------|---------|
 | ⭐ **Easy** | 404 Handling |
-| ⭐⭐ **Moderate** | Authentication Flow, Bottom Navigation, Route Transitions, Modal Routing, State Management, URL Strategies |
+| ⭐⭐ **Moderate** | Authentication Flow, Composable Route Guard Rules, Bottom Navigation, Route Transitions, Modal Routing, State Management, URL Strategies |
 | ⭐⭐⭐ **Advanced** | Nested Navigation, Route Versioning |
 
 ---

--- a/packages/zenrouter/doc/recipes/route-guard-rules.md
+++ b/packages/zenrouter/doc/recipes/route-guard-rules.md
@@ -1,0 +1,149 @@
+# Recipe: Composable Route Guard Rules
+
+## Problem
+
+You need to block leaving a screen under several independent conditions — unsaved
+edits, an upload in progress, a "are you sure?" confirmation — and reuse those
+checks across many routes without copying `popGuard` into every class.
+
+## Solution Overview
+
+Use **`RouteGuardRule`** with a list of **`GuardRule`**s:
+
+- Each rule returns `bool?`: `null` = continue, `true` = allow, `false` = block
+- Sync `canPop` / `canPopListenable` drive Flutter `PopScope` (free back when safe)
+- Rules stay unit-testable and reusable across editor, settings, checkout, etc.
+
+```
+System back / gesture
+        │
+        ▼
+   canPop? ──true──► pop immediately (no dialog)
+        │
+      false
+        ▼
+   GuardRule chain (first non-null wins)
+        │
+   ┌────┴────┐
+ null      true/false
+  │           │
+ next      allow / block
+```
+
+## Complete Code Example
+
+Runnable sample:
+
+```bash
+cd packages/zenrouter/example
+flutter run -t lib/main_guard_rules.dart
+```
+
+Source: [`example/lib/main_guard_rules.dart`](../../example/lib/main_guard_rules.dart)
+
+Highlights from that file:
+
+```dart
+class UnsavedChangesRule extends GuardRule<AppRoute> {
+  @override
+  bool canPop(AppRoute route) =>
+      route is! EditableRoute || !route.hasUnsavedChanges;
+
+  @override
+  ListenableMixin? canPopListenable(AppRoute route) =>
+      route is EditableRoute ? route.dirty.toListenableMixin() : null;
+
+  @override
+  Future<bool?> guard(covariant GuardRulesCoordinator c, AppRoute route) async {
+    if (route is! EditableRoute || !route.hasUnsavedChanges) return null;
+    return showDiscardDialog(c.navigator.context);
+  }
+}
+
+class UploadRoute extends AppRoute
+    with EditableRoute, UploadableRoute, RouteGuardRule<AppRoute> {
+  @override
+  List<GuardRule> get guardRules => const [
+    GuardAuditRule(),
+    UploadInProgressRule(), // first decisive blocker
+    UnsavedChangesRule(),
+  ];
+}
+```
+
+## How the chain works
+
+| Rule return | Meaning |
+|-------------|---------|
+| `null` | No opinion — try the next rule |
+| `true` | Allow pop — **stop** the chain |
+| `false` | Block pop — **stop** the chain |
+
+| Sync API | Meaning |
+|----------|---------|
+| `canPop → true` | This rule does not force `PopScope` intercept |
+| `canPop → false` | Force intercept; then run `guard` |
+| `canPopListenable` | Rebuild `PopScope` when dirty/uploading flips |
+| Empty / all-`null` guards | Pop is **allowed** |
+
+`RouteGuardRule.canPop` is `true` only when **every** rule returns `canPop == true`.
+`canPopListenable` merges all rule listenables via `ListenableMixin.merge`.
+
+### Example walkthrough — `UploadRoute`
+
+1. User is uploading (`uploading == true`) and typed a caption (`dirty == true`).
+2. `canPop` is `false` (upload rule + unsaved rule).
+3. System back → intercept → `popGuardWith` runs:
+   - `GuardAuditRule` → `null`
+   - `UploadInProgressRule` → dialog; if user cancels leave → `false` → **blocked**
+   - If user confirms cancel upload → `true` → **allowed** (unsaved rule never runs)
+4. After upload finishes, only unsaved rule still intercepts until caption is cleared.
+
+## Unit-testing rules
+
+Rules are plain classes — no widget tree required:
+
+```dart
+test('UnsavedChangesRule continues when route is not editable', () async {
+  final rule = const UnsavedChangesRule();
+  final route = HomeRoute(); // not EditableRoute
+
+  expect(rule.canPop(route), isTrue);
+  expect(rule.canPopListenable(route), isNull);
+  expect(
+    await rule.guard(_FakeCoordinator(), route),
+    isNull,
+  );
+});
+
+test('UnsavedChangesRule blocks when dirty and dialog declines', () async {
+  // Inject a dialog stub / use a test coordinator with a known context
+});
+```
+
+## Common gotchas
+
+1. **Order matters** — put cheap / hard blockers first (upload), soft prompts later (unsaved).
+2. **`canPop` vs `popGuard`** — programmatic `coordinator.pop()` always runs `guard`, even when `canPop` is `true`.
+3. **Use `toListenableMixin()`** — Flutter `ValueNotifier` is not a `ListenableMixin`; wrap it:
+   ```dart
+   dirty.toListenableMixin()
+   ```
+4. **Rebuild PopScope** — without `canPopListenable`, flipping dirty will not update system-back behavior until the page is rebuilt.
+5. **Don’t put `RouteGuard` on login-only flows that should never intercept** — or override `canPop => true` and return `true` from `guard`.
+6. **Entry protection is redirect, not guard** — auth “can I open this?” belongs in `RouteRedirect` / `RedirectRule`.
+
+## When to use what
+
+| Situation | API |
+|-----------|-----|
+| One-off leave check on a single route | `RouteGuard` + `popGuard` |
+| Same leave logic on many routes | `RouteGuardRule` + shared `GuardRule`s |
+| Free predictive back when clean | `canPop` + `canPopListenable` |
+| Block opening a route (auth) | `RouteRedirect` / `RouteRedirectRule` |
+
+## Related
+
+- [Authentication Flow](authentication-flow.md) — entry redirects
+- [Mixins API — RouteGuard / RouteGuardRule](../api/mixins.md)
+- [ADVANCED.md — GuardRule](../../../skills/zenrouter/ADVANCED.md) (repo skill)

--- a/packages/zenrouter/example/lib/main_guard_rules.dart
+++ b/packages/zenrouter/example/lib/main_guard_rules.dart
@@ -293,7 +293,10 @@ class HomeRoute extends AppRoute {
   Uri toUri() => Uri.parse('/');
 
   @override
-  Widget build(covariant GuardRulesCoordinator coordinator, BuildContext context) {
+  Widget build(
+    covariant GuardRulesCoordinator coordinator,
+    BuildContext context,
+  ) {
     return Scaffold(
       appBar: AppBar(title: const Text('Guard Rules Demo')),
       body: ListView(
@@ -348,7 +351,10 @@ class EditorRoute extends AppRoute
   Uri toUri() => Uri.parse('/editor/$documentId');
 
   @override
-  Widget build(covariant GuardRulesCoordinator coordinator, BuildContext context) {
+  Widget build(
+    covariant GuardRulesCoordinator coordinator,
+    BuildContext context,
+  ) {
     return Scaffold(
       appBar: AppBar(
         title: Text('Editor $documentId'),
@@ -370,9 +376,13 @@ class EditorRoute extends AppRoute
             ValueListenableBuilder<bool>(
               valueListenable: dirty,
               builder: (context, isDirty, _) => Text(
-                isDirty ? 'Status: unsaved changes' : 'Status: clean (free back)',
+                isDirty
+                    ? 'Status: unsaved changes'
+                    : 'Status: clean (free back)',
                 style: TextStyle(
-                  color: isDirty ? Colors.orange.shade800 : Colors.green.shade700,
+                  color: isDirty
+                      ? Colors.orange.shade800
+                      : Colors.green.shade700,
                   fontWeight: FontWeight.w600,
                 ),
               ),
@@ -405,7 +415,10 @@ class SettingsRoute extends AppRoute with RouteGuardRule<AppRoute> {
   Uri toUri() => Uri.parse('/settings');
 
   @override
-  Widget build(covariant GuardRulesCoordinator coordinator, BuildContext context) {
+  Widget build(
+    covariant GuardRulesCoordinator coordinator,
+    BuildContext context,
+  ) {
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
       body: const Padding(
@@ -439,7 +452,10 @@ class UploadRoute extends AppRoute
   Uri toUri() => Uri.parse('/upload/$jobId');
 
   @override
-  Widget build(covariant GuardRulesCoordinator coordinator, BuildContext context) {
+  Widget build(
+    covariant GuardRulesCoordinator coordinator,
+    BuildContext context,
+  ) {
     return Scaffold(
       appBar: AppBar(title: Text('Upload $jobId')),
       body: Padding(

--- a/packages/zenrouter/example/lib/main_guard_rules.dart
+++ b/packages/zenrouter/example/lib/main_guard_rules.dart
@@ -1,0 +1,523 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:zenrouter/zenrouter.dart';
+import 'package:zenrouter_devtools/zenrouter_devtools.dart';
+
+/// =============================================================================
+/// ROUTE GUARD RULES EXAMPLE
+/// =============================================================================
+/// Demonstrates composable [RouteGuardRule] / [GuardRule]:
+///
+/// - UnsavedChangesRule — reactive canPop + discard dialog
+/// - UploadInProgressRule — block leave while uploading
+/// - ConfirmLeaveRule — always confirm
+/// - GuardAuditRule — logging only (always continues)
+///
+/// Run:
+///   flutter run -t lib/main_guard_rules.dart
+/// =============================================================================
+
+void main() {
+  runApp(const GuardRulesApp());
+}
+
+class GuardRulesApp extends StatelessWidget {
+  const GuardRulesApp({super.key});
+
+  static final coordinator = GuardRulesCoordinator();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: 'ZenRouter Guard Rules',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
+        useMaterial3: true,
+      ),
+      routerDelegate: coordinator.routerDelegate,
+      routeInformationParser: coordinator.routeInformationParser,
+    );
+  }
+}
+
+// =============================================================================
+// Coordinator
+// =============================================================================
+
+class GuardRulesCoordinator extends Coordinator<AppRoute>
+    with CoordinatorDebug {
+  @override
+  Uri? get initialRoutePath => Uri.parse('/');
+
+  @override
+  List<AppRoute> get debugRoutes => [
+    HomeRoute(),
+    EditorRoute(documentId: 'demo'),
+    SettingsRoute(),
+    UploadRoute(jobId: 'job-1'),
+  ];
+
+  @override
+  AppRoute parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      [] => HomeRoute(),
+      ['editor', final id] => EditorRoute(documentId: id),
+      ['settings'] => SettingsRoute(),
+      ['upload', final id] => UploadRoute(jobId: id),
+      _ => HomeRoute(),
+    };
+  }
+}
+
+// =============================================================================
+// Route base
+// =============================================================================
+
+abstract class AppRoute extends RouteTarget with RouteUnique {}
+
+// =============================================================================
+// Shared dialogs
+// =============================================================================
+
+Future<bool> showDiscardDialog(BuildContext context) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Discard changes?'),
+      content: const Text('You have unsaved changes. Leave without saving?'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: const Text('Stay'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, true),
+          style: TextButton.styleFrom(foregroundColor: Colors.red),
+          child: const Text('Discard'),
+        ),
+      ],
+    ),
+  );
+  return result ?? false;
+}
+
+Future<bool> showCancelUploadDialog(BuildContext context) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Cancel upload?'),
+      content: const Text('Upload is still in progress.'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: const Text('Keep uploading'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, true),
+          child: const Text('Cancel upload'),
+        ),
+      ],
+    ),
+  );
+  return result ?? false;
+}
+
+Future<bool> showConfirmLeaveDialog(BuildContext context) async {
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Leave this screen?'),
+      content: const Text('This action cannot be undone.'),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context, false),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.pop(context, true),
+          child: const Text('Leave'),
+        ),
+      ],
+    ),
+  );
+  return result ?? false;
+}
+
+// =============================================================================
+// GuardRules
+// =============================================================================
+
+/// Blocks leave while a form has unsaved edits.
+class UnsavedChangesRule extends GuardRule<AppRoute> {
+  const UnsavedChangesRule();
+
+  @override
+  bool canPop(AppRoute route) {
+    if (route is! EditableRoute) return true;
+    return !route.hasUnsavedChanges;
+  }
+
+  @override
+  ListenableMixin? canPopListenable(AppRoute route) {
+    if (route is! EditableRoute) return null;
+    return route.dirty.toListenableMixin();
+  }
+
+  @override
+  Future<bool?> guard(
+    covariant GuardRulesCoordinator coordinator,
+    AppRoute route,
+  ) async {
+    if (route is! EditableRoute || !route.hasUnsavedChanges) return null;
+    final context = coordinator.navigator.context;
+    if (!context.mounted) return false;
+    return showDiscardDialog(context);
+  }
+}
+
+/// Blocks leave while an upload job is running.
+class UploadInProgressRule extends GuardRule<AppRoute> {
+  const UploadInProgressRule();
+
+  @override
+  bool canPop(AppRoute route) {
+    if (route is! UploadableRoute) return true;
+    return !route.isUploading;
+  }
+
+  @override
+  ListenableMixin? canPopListenable(AppRoute route) {
+    if (route is! UploadableRoute) return null;
+    return route.uploading.toListenableMixin();
+  }
+
+  @override
+  Future<bool?> guard(
+    covariant GuardRulesCoordinator coordinator,
+    AppRoute route,
+  ) async {
+    if (route is! UploadableRoute || !route.isUploading) return null;
+    final context = coordinator.navigator.context;
+    if (!context.mounted) return false;
+    final leave = await showCancelUploadDialog(context);
+    if (leave) route.cancelUpload();
+    return leave;
+  }
+}
+
+/// Always asks for confirmation.
+class ConfirmLeaveRule extends GuardRule<AppRoute> {
+  const ConfirmLeaveRule();
+
+  @override
+  bool canPop(AppRoute route) => false;
+
+  @override
+  Future<bool?> guard(
+    covariant GuardRulesCoordinator coordinator,
+    AppRoute route,
+  ) async {
+    final context = coordinator.navigator.context;
+    if (!context.mounted) return false;
+    return showConfirmLeaveDialog(context);
+  }
+}
+
+/// Logging only — never decides; always continues.
+class GuardAuditRule extends GuardRule<AppRoute> {
+  const GuardAuditRule();
+
+  @override
+  Future<bool?> guard(
+    covariant GuardRulesCoordinator coordinator,
+    AppRoute route,
+  ) async {
+    debugPrint('[GuardAudit] pop attempted from ${route.toUri()}');
+    return null;
+  }
+}
+
+// =============================================================================
+// Route capability mixins
+// =============================================================================
+
+mixin EditableRoute on AppRoute {
+  final dirty = ValueNotifier(false);
+
+  bool get hasUnsavedChanges => dirty.value;
+
+  void markDirty() => dirty.value = true;
+
+  void markClean() => dirty.value = false;
+
+  @override
+  void onDiscard() {
+    dirty.dispose();
+    super.onDiscard();
+  }
+}
+
+mixin UploadableRoute on AppRoute {
+  final uploading = ValueNotifier(false);
+  Timer? _uploadTimer;
+
+  bool get isUploading => uploading.value;
+
+  void startUpload({Duration duration = const Duration(seconds: 8)}) {
+    _uploadTimer?.cancel();
+    uploading.value = true;
+    _uploadTimer = Timer(duration, cancelUpload);
+  }
+
+  void cancelUpload() {
+    _uploadTimer?.cancel();
+    _uploadTimer = null;
+    uploading.value = false;
+  }
+
+  @override
+  void onDiscard() {
+    cancelUpload();
+    uploading.dispose();
+    super.onDiscard();
+  }
+}
+
+// =============================================================================
+// Routes
+// =============================================================================
+
+class HomeRoute extends AppRoute {
+  @override
+  Uri toUri() => Uri.parse('/');
+
+  @override
+  Widget build(covariant GuardRulesCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Guard Rules Demo')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text(
+            'Try system back / AppBar back on each screen.\n'
+            'Clean screens pop freely; dirty / uploading / confirm screens intercept.',
+            style: TextStyle(height: 1.4),
+          ),
+          const SizedBox(height: 16),
+          _DemoCard(
+            icon: Icons.edit_note,
+            title: 'Editor',
+            subtitle: 'UnsavedChangesRule — type to mark dirty',
+            onTap: () => coordinator.push(EditorRoute(documentId: '42')),
+          ),
+          _DemoCard(
+            icon: Icons.settings,
+            title: 'Settings',
+            subtitle: 'ConfirmLeaveRule — always asks',
+            onTap: () => coordinator.push(SettingsRoute()),
+          ),
+          _DemoCard(
+            icon: Icons.cloud_upload,
+            title: 'Upload',
+            subtitle: 'Upload + unsaved caption (rule chain)',
+            onTap: () => coordinator.push(UploadRoute(jobId: 'job-1')),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class EditorRoute extends AppRoute
+    with EditableRoute, RouteGuardRule<AppRoute> {
+  EditorRoute({required this.documentId});
+
+  final String documentId;
+
+  @override
+  List<Object?> get props => [documentId];
+
+  @override
+  List<GuardRule> get guardRules => const [
+    GuardAuditRule(),
+    UnsavedChangesRule(),
+  ];
+
+  @override
+  Uri toUri() => Uri.parse('/editor/$documentId');
+
+  @override
+  Widget build(covariant GuardRulesCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Editor $documentId'),
+        actions: [
+          ValueListenableBuilder<bool>(
+            valueListenable: dirty,
+            builder: (context, isDirty, _) => TextButton(
+              onPressed: isDirty ? markClean : null,
+              child: Text(isDirty ? 'Save' : 'Saved'),
+            ),
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ValueListenableBuilder<bool>(
+              valueListenable: dirty,
+              builder: (context, isDirty, _) => Text(
+                isDirty ? 'Status: unsaved changes' : 'Status: clean (free back)',
+                style: TextStyle(
+                  color: isDirty ? Colors.orange.shade800 : Colors.green.shade700,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: TextField(
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: 'Start typing to mark dirty…',
+                ),
+                onChanged: (_) => markDirty(),
+                maxLines: null,
+                expands: true,
+                textAlignVertical: TextAlignVertical.top,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class SettingsRoute extends AppRoute with RouteGuardRule<AppRoute> {
+  @override
+  List<GuardRule> get guardRules => const [ConfirmLeaveRule()];
+
+  @override
+  Uri toUri() => Uri.parse('/settings');
+
+  @override
+  Widget build(covariant GuardRulesCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: const Padding(
+        padding: EdgeInsets.all(16),
+        child: Text(
+          'Back always shows a confirmation dialog '
+          '(ConfirmLeaveRule.canPop → false).',
+        ),
+      ),
+    );
+  }
+}
+
+class UploadRoute extends AppRoute
+    with EditableRoute, UploadableRoute, RouteGuardRule<AppRoute> {
+  UploadRoute({required this.jobId});
+
+  final String jobId;
+
+  @override
+  List<Object?> get props => [jobId];
+
+  @override
+  List<GuardRule> get guardRules => const [
+    GuardAuditRule(),
+    UploadInProgressRule(),
+    UnsavedChangesRule(),
+  ];
+
+  @override
+  Uri toUri() => Uri.parse('/upload/$jobId');
+
+  @override
+  Widget build(covariant GuardRulesCoordinator coordinator, BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Upload $jobId')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ValueListenableBuilder<bool>(
+              valueListenable: uploading,
+              builder: (context, isUploading, _) {
+                return ValueListenableBuilder<bool>(
+                  valueListenable: dirty,
+                  builder: (context, isDirty, _) => Text(
+                    'Upload: ${isUploading ? "in progress" : "idle"} · '
+                    'Caption: ${isDirty ? "unsaved" : "clean"}',
+                    style: const TextStyle(fontWeight: FontWeight.w600),
+                  ),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: 'Caption',
+              ),
+              onChanged: (_) => markDirty(),
+            ),
+            const SizedBox(height: 16),
+            ValueListenableBuilder<bool>(
+              valueListenable: uploading,
+              builder: (context, isUploading, _) => FilledButton.icon(
+                onPressed: isUploading ? null : () => startUpload(),
+                icon: const Icon(Icons.cloud_upload),
+                label: Text(isUploading ? 'Uploading…' : 'Start upload (8s)'),
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'While uploading, back asks to cancel the upload first.\n'
+              'If upload is idle but caption is dirty, discard dialog runs.',
+              style: TextStyle(height: 1.4),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// =============================================================================
+// UI helpers
+// =============================================================================
+
+class _DemoCard extends StatelessWidget {
+  const _DemoCard({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        leading: Icon(icon, size: 32),
+        title: Text(title),
+        subtitle: Text(subtitle),
+        trailing: const Icon(Icons.chevron_right),
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/packages/zenrouter/lib/src/coordinator/router.dart
+++ b/packages/zenrouter/lib/src/coordinator/router.dart
@@ -120,10 +120,8 @@ class CoordinatorRouterDelegate extends RouterDelegate<Uri>
     );
 
     if (route case RouteDeepLink()) {
-      final deeplink = route as RouteDeepLink;
-      if (deeplink.deeplinkStrategy == DeeplinkStrategy.custom) {
-        coordinator.recover(route!);
-      }
+      // Not awaited: recover → push/navigate futures complete on pop.
+      coordinator.recover(route!);
       return;
     }
 
@@ -131,6 +129,7 @@ class CoordinatorRouterDelegate extends RouterDelegate<Uri>
       route != null,
       'You must to provide a parse route for $configuration in [parseRouteFromUri] to use deeplink to it',
     );
+    // Not awaited: navigate → push future completes when the route is popped.
     coordinator.navigate(route!);
   }
 

--- a/packages/zenrouter/lib/src/internal/reactive.dart
+++ b/packages/zenrouter/lib/src/internal/reactive.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart' as flutter;
+import 'package:zenrouter_core/zenrouter_core.dart';
+
+/// Adapts a Flutter foundation [flutter.Listenable] (`ValueNotifier`,
+/// `ChangeNotifier`, etc.) to [ListenableMixin] for
+/// [RouteGuard.canPopListenable].
+///
+/// Prefer [ListenableToListenableMixin.toListenableMixin]:
+///
+/// ```dart
+/// final dirty = ValueNotifier(false);
+///
+/// @override
+/// ListenableMixin? get canPopListenable => dirty.toListenableMixin();
+/// ```
+class FlutterListenableMixin implements ListenableMixin {
+  /// Creates an adapter around a Flutter [flutter.Listenable].
+  FlutterListenableMixin(this._listenable);
+
+  final flutter.Listenable _listenable;
+
+  @override
+  void addListener(void Function() listener) =>
+      _listenable.addListener(listener);
+
+  @override
+  void removeListener(void Function() listener) =>
+      _listenable.removeListener(listener);
+}
+
+/// Converts a Flutter [flutter.Listenable] to [ListenableMixin].
+extension ListenableToListenableMixin on flutter.Listenable {
+  /// Wraps this listenable as a [ListenableMixin] for
+  /// [RouteGuard.canPopListenable].
+  ListenableMixin toListenableMixin() => FlutterListenableMixin(this);
+}
+
+/// Adapts a [ListenableMixin] to Flutter's [flutter.Listenable] for use with
+/// [ListenableBuilder] / [AnimatedBuilder].
+class ListenableMixinToFlutter extends flutter.Listenable {
+  /// Creates an adapter around a [ListenableMixin].
+  ListenableMixinToFlutter(this._listenable);
+
+  final ListenableMixin _listenable;
+
+  @override
+  void addListener(flutter.VoidCallback listener) =>
+      _listenable.addListener(listener);
+
+  @override
+  void removeListener(flutter.VoidCallback listener) =>
+      _listenable.removeListener(listener);
+}
+
+/// Converts a [ListenableMixin] to Flutter's [flutter.Listenable].
+extension ListenableMixinToFlutterListenable on ListenableMixin {
+  /// Wraps this mixin as a Flutter [flutter.Listenable] for
+  /// [ListenableBuilder] / [AnimatedBuilder].
+  flutter.Listenable toFlutterListenable() => ListenableMixinToFlutter(this);
+}

--- a/packages/zenrouter/lib/src/path/stack.dart
+++ b/packages/zenrouter/lib/src/path/stack.dart
@@ -3,10 +3,12 @@ import 'package:flutter/material.dart';
 import 'package:zenrouter/src/coordinator/base.dart';
 import 'package:zenrouter/src/coordinator/observer.dart';
 import 'package:zenrouter/src/internal/type.dart';
+import 'package:zenrouter/src/internal/reactive.dart';
 import 'package:zenrouter/src/mixin/unique.dart';
 import 'package:zenrouter/src/path/indexed.dart';
 import 'package:zenrouter/src/path/navigation.dart';
 import 'package:zenrouter/src/path/restoration.dart';
+import 'package:zenrouter/src/path/transition.dart';
 import 'package:zenrouter_core/zenrouter_core.dart';
 
 /// A widget that renders a stack of pages based on a [NavigationPath].
@@ -137,15 +139,30 @@ class _NavigationStackState<T extends RouteTarget>
     // ignore: invalid_use_of_protected_member
     route.bindStackPath(widget.path);
     final destination = widget.resolver(route);
+    final RouteGuard? guard = switch (route) {
+      final RouteGuard routeGuard => routeGuard,
+      _ => destination.guard,
+    };
+
     return destination.pageBuilder(
       context,
       ValueKey(route),
-      PopScope(
-        canPop: switch (route) {
-          RouteGuard() => false,
-          _ when destination.guard != null => false,
-          _ => true,
-        },
+      _buildPopScope(
+        route: route,
+        guard: guard,
+        destination: destination,
+      ),
+    );
+  }
+
+  Widget _buildPopScope({
+    required T route,
+    required RouteGuard? guard,
+    required StackTransition<T> destination,
+  }) {
+    Widget buildScope(bool canPop) {
+      return PopScope(
+        canPop: canPop,
         onPopInvokedWithResult: (didPop, result) async {
           // ignore: invalid_use_of_protected_member
           if (route.stackPath == null) route.bindStackPath(widget.path);
@@ -187,7 +204,17 @@ class _NavigationStackState<T extends RouteTarget>
           }
         },
         child: destination.builder(context),
-      ),
+      );
+    }
+
+    if (guard == null) return buildScope(true);
+
+    final canPopListenable = guard.canPopListenable;
+    if (canPopListenable == null) return buildScope(guard.canPop);
+
+    return ListenableBuilder(
+      listenable: canPopListenable.toFlutterListenable(),
+      builder: (context, _) => buildScope(guard.canPop),
     );
   }
 

--- a/packages/zenrouter/lib/src/path/stack.dart
+++ b/packages/zenrouter/lib/src/path/stack.dart
@@ -147,11 +147,7 @@ class _NavigationStackState<T extends RouteTarget>
     return destination.pageBuilder(
       context,
       ValueKey(route),
-      _buildPopScope(
-        route: route,
-        guard: guard,
-        destination: destination,
-      ),
+      _buildPopScope(route: route, guard: guard, destination: destination),
     );
   }
 

--- a/packages/zenrouter/lib/zenrouter.dart
+++ b/packages/zenrouter/lib/zenrouter.dart
@@ -25,6 +25,12 @@ export 'src/mixin/query_parameters.dart';
 export 'src/mixin/transition.dart';
 export 'src/mixin/unique.dart';
 export 'src/mixin/restoration.dart';
+export 'src/internal/reactive.dart'
+    show
+        ListenableMixinToFlutterListenable,
+        ListenableToListenableMixin,
+        FlutterListenableMixin,
+        ListenableMixinToFlutter;
 
 /// Internal types
 export 'src/internal/type.dart';

--- a/packages/zenrouter/test/mixin/guard_rule_test.dart
+++ b/packages/zenrouter/test/mixin/guard_rule_test.dart
@@ -1,0 +1,389 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zenrouter/zenrouter.dart';
+
+void main() {
+  group('RouteGuardRule Tests', () {
+    testWidgets('empty rules allow pop', (tester) async {
+      final coordinator = GuardRuleTestCoordinator();
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerDelegate: coordinator.routerDelegate,
+          routeInformationParser: coordinator.routeInformationParser,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.push(RuleGuardedRoute(id: '1', rules: []));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Rule Guarded: 1'), findsOneWidget);
+
+      coordinator.pop();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Home'), findsOneWidget);
+    });
+
+    testWidgets('null-only rules allow pop', (tester) async {
+      final coordinator = GuardRuleTestCoordinator();
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerDelegate: coordinator.routerDelegate,
+          routeInformationParser: coordinator.routeInformationParser,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.push(
+        RuleGuardedRoute(id: '2', rules: [const ContinueGuardRule()]),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.pop();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Home'), findsOneWidget);
+    });
+
+    testWidgets('false blocks pop', (tester) async {
+      final coordinator = GuardRuleTestCoordinator();
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerDelegate: coordinator.routerDelegate,
+          routeInformationParser: coordinator.routeInformationParser,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.push(
+        RuleGuardedRoute(id: '3', rules: [const BlockGuardRule()]),
+      );
+      await tester.pumpAndSettle();
+
+      final stackLengthBefore = coordinator.root.stack.length;
+
+      coordinator.pop();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Rule Guarded: 3'), findsOneWidget);
+      expect(coordinator.root.stack.length, stackLengthBefore);
+    });
+
+    testWidgets('true allows pop and skips later rules', (tester) async {
+      final coordinator = GuardRuleTestCoordinator();
+      final later = CountingGuardRule(false);
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerDelegate: coordinator.routerDelegate,
+          routeInformationParser: coordinator.routeInformationParser,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.push(
+        RuleGuardedRoute(
+          id: '4',
+          rules: [const AllowGuardRule(), later],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.pop();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Home'), findsOneWidget);
+      expect(later.callCount, 0);
+    });
+
+    testWidgets('null continues to next rule which can block', (tester) async {
+      final coordinator = GuardRuleTestCoordinator();
+      final second = CountingGuardRule(false);
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerDelegate: coordinator.routerDelegate,
+          routeInformationParser: coordinator.routeInformationParser,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.push(
+        RuleGuardedRoute(
+          id: '5',
+          rules: [const ContinueGuardRule(), second],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final stackLengthBefore = coordinator.root.stack.length;
+
+      coordinator.pop();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Rule Guarded: 5'), findsOneWidget);
+      expect(coordinator.root.stack.length, stackLengthBefore);
+      expect(second.callCount, 1);
+    });
+
+    testWidgets('false short-circuits and skips later rules', (tester) async {
+      final coordinator = GuardRuleTestCoordinator();
+      final later = CountingGuardRule(true);
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerDelegate: coordinator.routerDelegate,
+          routeInformationParser: coordinator.routeInformationParser,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.push(
+        RuleGuardedRoute(
+          id: '6',
+          rules: [const BlockGuardRule(), later],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.pop();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Rule Guarded: 6'), findsOneWidget);
+      expect(later.callCount, 0);
+    });
+
+    testWidgets('async guard rules work correctly', (tester) async {
+      final coordinator = GuardRuleTestCoordinator();
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerDelegate: coordinator.routerDelegate,
+          routeInformationParser: coordinator.routeInformationParser,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.push(
+        RuleGuardedRoute(
+          id: '7',
+          rules: [
+            AsyncGuardRule(
+              true,
+              delay: const Duration(milliseconds: 50),
+            ),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.pop();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Home'), findsOneWidget);
+    });
+
+    testWidgets('IndexedStack tab leave respects guard rules', (tester) async {
+      final coordinator = GuardRuleTestCoordinator();
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerDelegate: coordinator.routerDelegate,
+          routeInformationParser: coordinator.routeInformationParser,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.push(FirstTab());
+      await tester.pumpAndSettle();
+
+      expect(coordinator.indexedStackPath.activeIndex, 0);
+
+      // Leaving FirstTab is blocked by BlockGuardRule
+      await coordinator.indexedStackPath.goToIndexed(1);
+      await tester.pumpAndSettle();
+
+      expect(coordinator.indexedStackPath.activeIndex, 0);
+    });
+  });
+}
+
+// ============================================================================
+// Test Routes
+// ============================================================================
+
+abstract class GuardRuleTestRoute extends RouteTarget with RouteUnique {}
+
+class HomeRoute extends GuardRuleTestRoute {
+  @override
+  Uri toUri() => Uri.parse('/');
+
+  @override
+  Widget build(
+    covariant Coordinator<RouteUnique> coordinator,
+    BuildContext context,
+  ) {
+    return const Scaffold(body: Center(child: Text('Home')));
+  }
+}
+
+class RuleGuardedRoute extends GuardRuleTestRoute
+    with RouteGuardRule<GuardRuleTestRoute> {
+  RuleGuardedRoute({required this.id, required this.rules});
+
+  final String id;
+  final List<GuardRule> rules;
+
+  @override
+  List<GuardRule> get guardRules => rules;
+
+  @override
+  Uri toUri() => Uri.parse('/rule-guarded/$id');
+
+  @override
+  Widget build(
+    covariant Coordinator<RouteUnique> coordinator,
+    BuildContext context,
+  ) {
+    return Scaffold(body: Center(child: Text('Rule Guarded: $id')));
+  }
+
+  @override
+  List<Object?> get props => [id, ...rules];
+}
+
+class TestIndexedStackLayout extends GuardRuleTestRoute with RouteLayout {
+  @override
+  StackPath<RouteUnique> resolvePath(
+    covariant GuardRuleTestCoordinator coordinator,
+  ) => coordinator.indexedStackPath;
+}
+
+class FirstTab extends GuardRuleTestRoute
+    with RouteGuardRule<GuardRuleTestRoute> {
+  @override
+  Type get layout => TestIndexedStackLayout;
+
+  @override
+  List<GuardRule> get guardRules => [const BlockGuardRule()];
+
+  @override
+  Widget build(covariant Coordinator coordinator, BuildContext context) {
+    return const Center(child: Text('First Tab'));
+  }
+
+  @override
+  Uri toUri() => Uri.parse('/first-tab');
+}
+
+class SecondTab extends GuardRuleTestRoute {
+  @override
+  Type get layout => TestIndexedStackLayout;
+
+  @override
+  Widget build(covariant Coordinator coordinator, BuildContext context) {
+    return const Center(child: Text('Second Tab'));
+  }
+
+  @override
+  Uri toUri() => Uri.parse('/second-tab');
+}
+
+// ============================================================================
+// Test Guard Rules
+// ============================================================================
+
+class ContinueGuardRule extends GuardRule<GuardRuleTestRoute> {
+  const ContinueGuardRule();
+
+  @override
+  FutureOr<bool?> guard(
+    covariant Coordinator coordinator,
+    covariant GuardRuleTestRoute route,
+  ) => null;
+}
+
+class AllowGuardRule extends GuardRule<GuardRuleTestRoute> {
+  const AllowGuardRule();
+
+  @override
+  FutureOr<bool?> guard(
+    covariant Coordinator coordinator,
+    covariant GuardRuleTestRoute route,
+  ) => true;
+}
+
+class BlockGuardRule extends GuardRule<GuardRuleTestRoute> {
+  const BlockGuardRule();
+
+  @override
+  FutureOr<bool?> guard(
+    covariant Coordinator coordinator,
+    covariant GuardRuleTestRoute route,
+  ) => false;
+}
+
+class CountingGuardRule extends GuardRule<GuardRuleTestRoute> {
+  CountingGuardRule(this.result);
+
+  final bool? result;
+  int callCount = 0;
+
+  @override
+  FutureOr<bool?> guard(
+    covariant Coordinator coordinator,
+    covariant GuardRuleTestRoute route,
+  ) {
+    callCount++;
+    return result;
+  }
+}
+
+class AsyncGuardRule extends GuardRule<GuardRuleTestRoute> {
+  const AsyncGuardRule(this.result, {required this.delay});
+
+  final bool? result;
+  final Duration delay;
+
+  @override
+  Future<bool?> guard(
+    covariant Coordinator coordinator,
+    covariant GuardRuleTestRoute route,
+  ) async {
+    await Future.delayed(delay);
+    return result;
+  }
+}
+
+// ============================================================================
+// Test Coordinator
+// ============================================================================
+
+class GuardRuleTestCoordinator extends Coordinator<GuardRuleTestRoute> {
+  late final indexedStackPath = IndexedStackPath.createWith(
+    [FirstTab(), SecondTab()],
+    coordinator: this,
+    label: 'IndexedStackPath',
+  )..bindLayout(TestIndexedStackLayout.new);
+
+  @override
+  Uri? get initialRoutePath => Uri.parse('/');
+
+  @override
+  List<StackPath> get paths => [...super.paths, indexedStackPath];
+
+  @override
+  GuardRuleTestRoute parseRouteFromUri(Uri uri) {
+    return switch (uri.pathSegments) {
+      [] => HomeRoute(),
+      ['rule-guarded', final id] => RuleGuardedRoute(id: id, rules: []),
+      _ => HomeRoute(),
+    };
+  }
+}

--- a/packages/zenrouter/test/mixin/guard_rule_test.dart
+++ b/packages/zenrouter/test/mixin/guard_rule_test.dart
@@ -88,10 +88,7 @@ void main() {
       await tester.pumpAndSettle();
 
       coordinator.push(
-        RuleGuardedRoute(
-          id: '4',
-          rules: [const AllowGuardRule(), later],
-        ),
+        RuleGuardedRoute(id: '4', rules: [const AllowGuardRule(), later]),
       );
       await tester.pumpAndSettle();
 
@@ -115,10 +112,7 @@ void main() {
       await tester.pumpAndSettle();
 
       coordinator.push(
-        RuleGuardedRoute(
-          id: '5',
-          rules: [const ContinueGuardRule(), second],
-        ),
+        RuleGuardedRoute(id: '5', rules: [const ContinueGuardRule(), second]),
       );
       await tester.pumpAndSettle();
 
@@ -145,10 +139,7 @@ void main() {
       await tester.pumpAndSettle();
 
       coordinator.push(
-        RuleGuardedRoute(
-          id: '6',
-          rules: [const BlockGuardRule(), later],
-        ),
+        RuleGuardedRoute(id: '6', rules: [const BlockGuardRule(), later]),
       );
       await tester.pumpAndSettle();
 
@@ -174,10 +165,7 @@ void main() {
         RuleGuardedRoute(
           id: '7',
           rules: [
-            AsyncGuardRule(
-              true,
-              delay: const Duration(milliseconds: 50),
-            ),
+            AsyncGuardRule(true, delay: const Duration(milliseconds: 50)),
           ],
         ),
       );

--- a/packages/zenrouter/test/mixin/guard_test.dart
+++ b/packages/zenrouter/test/mixin/guard_test.dart
@@ -107,5 +107,45 @@ void main() {
       // Should eventually return to home
       expect(find.byKey(const ValueKey('simple-home')), findsOneWidget);
     });
+
+    testWidgets('reactive canPop updates PopScope without recreating page', (
+      tester,
+    ) async {
+      final coordinator = MixinTestCoordinator();
+      final route = ReactiveCanPopRoute();
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerDelegate: coordinator.routerDelegate,
+          routeInformationParser: coordinator.routeInformationParser,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      coordinator.push(route);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey('reactive-can-pop')), findsOneWidget);
+
+      PopScope<Object> popScopeOf(Finder content) {
+        final element = tester.element(content);
+        final popScope = element.findAncestorWidgetOfExactType<PopScope<Object>>();
+        expect(popScope, isNotNull);
+        return popScope!;
+      }
+
+      expect(
+        popScopeOf(find.byKey(const ValueKey('reactive-can-pop'))).canPop,
+        isTrue,
+      );
+
+      route.dirty.value = true;
+      await tester.pump();
+
+      expect(
+        popScopeOf(find.byKey(const ValueKey('reactive-can-pop'))).canPop,
+        isFalse,
+      );
+    });
   });
 }

--- a/packages/zenrouter/test/mixin/guard_test.dart
+++ b/packages/zenrouter/test/mixin/guard_test.dart
@@ -129,7 +129,8 @@ void main() {
 
       PopScope<Object> popScopeOf(Finder content) {
         final element = tester.element(content);
-        final popScope = element.findAncestorWidgetOfExactType<PopScope<Object>>();
+        final popScope = element
+            .findAncestorWidgetOfExactType<PopScope<Object>>();
         expect(popScope, isNotNull);
         return popScope!;
       }

--- a/packages/zenrouter/test/mixin/mixin_test_utils.dart
+++ b/packages/zenrouter/test/mixin/mixin_test_utils.dart
@@ -215,6 +215,34 @@ class GuardedPopRoute extends TestAppRoute with RouteGuard {
   List<Object?> get props => [allowPop, popDelay];
 }
 
+/// Route whose [canPop] tracks a Flutter [ValueNotifier] via bridge.
+class ReactiveCanPopRoute extends TestAppRoute with RouteGuard {
+  final dirty = ValueNotifier(false);
+
+  @override
+  ListenableMixin? get canPopListenable => dirty.toListenableMixin();
+
+  @override
+  bool get canPop => !dirty.value;
+
+  @override
+  Future<bool> popGuard() async => false;
+
+  @override
+  Uri toUri() => Uri.parse('/reactive-can-pop');
+
+  @override
+  Widget build(
+    covariant MixinTestCoordinator coordinator,
+    BuildContext context,
+  ) {
+    return const Scaffold(
+      key: ValueKey('reactive-can-pop'),
+      body: Text('Reactive CanPop'),
+    );
+  }
+}
+
 /// Route with guard that shows confirmation dialog
 class ConfirmationGuardRoute extends TestAppRoute with RouteGuard {
   ConfirmationGuardRoute({this.showConfirmation = true});

--- a/packages/zenrouter/test/mixin/mixin_test_utils.dart
+++ b/packages/zenrouter/test/mixin/mixin_test_utils.dart
@@ -241,6 +241,12 @@ class ReactiveCanPopRoute extends TestAppRoute with RouteGuard {
       body: Text('Reactive CanPop'),
     );
   }
+
+  @override
+  void onDiscard() {
+    dirty.dispose();
+    super.onDiscard();
+  }
 }
 
 /// Route with guard that shows confirmation dialog

--- a/packages/zenrouter/test/stack/route_completion_test.dart
+++ b/packages/zenrouter/test/stack/route_completion_test.dart
@@ -455,10 +455,7 @@ void main() {
             isA<StateError>().having(
               (e) => e.message,
               'message',
-              allOf(
-                contains('TestRoute'),
-                contains('expected RedirectRoute'),
-              ),
+              allOf(contains('TestRoute'), contains('expected RedirectRoute')),
             ),
           ),
         );

--- a/packages/zenrouter/test/stack/route_completion_test.dart
+++ b/packages/zenrouter/test/stack/route_completion_test.dart
@@ -442,6 +442,29 @@ void main() {
       expect(outerRedirect.resultCompleted, isTrue);
       expect(innerRedirect.resultCompleted, isTrue);
     });
+
+    test(
+      'throws StateError when redirect returns wrong type for resolve T',
+      () async {
+        final redirectRoute = RedirectRoute(redirectToId: 'target');
+
+        // redirect() returns TestRoute, which is not a RedirectRoute.
+        await expectLater(
+          () => RouteRedirect.resolve<RedirectRoute>(redirectRoute, null),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('TestRoute'),
+                contains('expected RedirectRoute'),
+              ),
+            ),
+          ),
+        );
+        expect(redirectRoute.resultCompleted, isTrue);
+      },
+    );
   });
 
   group('pushOrMoveToTop with RouteRedirect', () {

--- a/packages/zenrouter_core/README.md
+++ b/packages/zenrouter_core/README.md
@@ -485,5 +485,5 @@ export 'src/mixin/redirect_rule.dart';    // RedirectRule
 // Internal
 export 'src/internal/diff.dart';          // myersDiff, DiffOp, applyDiff
 export 'src/internal/equatable.dart';     // Equatable
-export 'src/internal/reactive.dart';     // ListenableObject
+export 'src/internal/reactive.dart';     // ListenableMixin, ListenableObject
 ```

--- a/packages/zenrouter_core/lib/src/coordinator/base.dart
+++ b/packages/zenrouter_core/lib/src/coordinator/base.dart
@@ -237,6 +237,10 @@ abstract class CoordinatorCore<T extends RouteUri> extends Equatable
   }
 
   /// Recovers navigation state from a route, respecting [RouteDeepLink] strategy.
+  ///
+  /// [navigate]/[push]/[replace] are intentionally not awaited: their futures
+  /// complete when the route is later popped (via [StackMutatable.push]), so
+  /// awaiting them would hang callers such as [recoverRouteFromUri].
   Future<void> recover(T route) async {
     T? target = await RouteRedirect.resolve(route, this);
     if (target == null) return;
@@ -402,7 +406,11 @@ abstract class CoordinatorCore<T extends RouteUri> extends Equatable
     return null;
   }
 
-  /// Pops from all eligible paths with at least two entries.
+  /// Pops from the nearest eligible path with at least two entries.
+  ///
+  /// Only the deepest mutatable path is popped. Unlike the previous
+  /// multi-path behavior, nested shells are not popped together with
+  /// their child stacks in a single call.
   Future<void> pop([Object? result]) async {
     final dynamicPaths = activePaths.whereType<StackMutatable>().toList();
 
@@ -410,6 +418,7 @@ abstract class CoordinatorCore<T extends RouteUri> extends Equatable
       final path = dynamicPaths[i];
       if (path.stack.length >= 2) {
         await path.pop(result);
+        return;
       }
     }
   }

--- a/packages/zenrouter_core/lib/src/internal/reactive.dart
+++ b/packages/zenrouter_core/lib/src/internal/reactive.dart
@@ -21,10 +21,12 @@ abstract mixin class ListenableMixin {
   ///
   /// Null entries are ignored. Once created, the iterable must not change.
   static ListenableMixin merge(Iterable<ListenableMixin?> listenables) =>
-      _MergingListenable(List<ListenableMixin>.unmodifiable([
-        for (final listenable in listenables)
-          if (listenable != null) listenable,
-      ]));
+      _MergingListenable(
+        List<ListenableMixin>.unmodifiable([
+          for (final listenable in listenables)
+            if (listenable != null) listenable,
+        ]),
+      );
 }
 
 class _MergingListenable implements ListenableMixin {

--- a/packages/zenrouter_core/lib/src/internal/reactive.dart
+++ b/packages/zenrouter_core/lib/src/internal/reactive.dart
@@ -2,18 +2,62 @@ import 'package:meta/meta.dart';
 
 typedef VoidCallback = void Function();
 
+/// Subscribe-only surface for reactive updates.
+///
+/// Used as the return type of [RouteGuard.canPopListenable] so routes can
+/// invalidate `PopScope` when [RouteGuard.canPop] may have changed, without
+/// depending on Flutter or `package:listen`.
+///
+/// In Flutter apps, convert a `ValueNotifier` / `ChangeNotifier` with
+/// `toListenableMixin()` from `package:zenrouter`.
+abstract mixin class ListenableMixin {
+  /// Register a closure to be called when this object notifies its listeners.
+  void addListener(VoidCallback listener);
+
+  /// Remove a previously registered closure from this object's listeners.
+  void removeListener(VoidCallback listener);
+
+  /// A [ListenableMixin] that notifies when any of [listenables] notify.
+  ///
+  /// Null entries are ignored. Once created, the iterable must not change.
+  static ListenableMixin merge(Iterable<ListenableMixin?> listenables) =>
+      _MergingListenable(List<ListenableMixin>.unmodifiable([
+        for (final listenable in listenables)
+          if (listenable != null) listenable,
+      ]));
+}
+
+class _MergingListenable implements ListenableMixin {
+  _MergingListenable(this._children);
+
+  final List<ListenableMixin> _children;
+
+  @override
+  void addListener(VoidCallback listener) {
+    for (final child in _children) {
+      child.addListener(listener);
+    }
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    for (final child in _children) {
+      child.removeListener(listener);
+    }
+  }
+
+  @override
+  String toString() => 'ListenableMixin.merge([${_children.join(', ')}])';
+}
+
 /// Mixin that provides listener management for observable objects.
 ///
 /// Used by [CoordinatorCore] and [StackPath] to notify dependents when
 /// navigation state changes. UI widgets listen to these changes to rebuild.
-mixin ListenableObject {
+mixin ListenableObject implements ListenableMixin {
   @mustCallSuper
   void dispose() {}
 
   @protected
   void notifyListeners();
-
-  void addListener(VoidCallback listener);
-
-  void removeListener(VoidCallback listener);
 }

--- a/packages/zenrouter_core/lib/src/mixin/guard.dart
+++ b/packages/zenrouter_core/lib/src/mixin/guard.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:zenrouter_core/src/coordinator/base.dart';
+import 'package:zenrouter_core/src/internal/reactive.dart';
 import 'package:zenrouter_core/src/mixin/target.dart';
 
 /// Mixin for routes that can intercept and block pop operations.
@@ -20,8 +21,48 @@ import 'package:zenrouter_core/src/mixin/target.dart';
 ///
 /// If any guard returns `false`, the pop operation is aborted and the
 /// navigation state remains unchanged.
+///
+/// ## System back vs programmatic pop
+///
+/// - [canPop] maps to Flutter's `PopScope.canPop`. When `true`, the platform
+///   may pop without calling [popGuard]. When `false` (default), the pop is
+///   intercepted and [popGuard] / [popGuardWith] decide.
+/// - Programmatic [StackMutatable.pop] always consults [popGuard], regardless
+///   of [canPop].
+/// - Provide [canPopListenable] so `PopScope` rebuilds when [canPop] changes
+///   without recreating the page.
 mixin RouteGuard on RouteTarget {
   // coverage:ignore-start
+  /// Whether the platform may pop this route without consulting [popGuard].
+  ///
+  /// Mapped to Flutter's `PopScope.canPop`.
+  ///
+  /// - `true` — system back / gesture pops immediately; [popGuard] is not
+  ///   called for that gesture.
+  /// - `false` — intercept; then [popGuard] / [popGuardWith] decide.
+  ///
+  /// Defaults to `false` (always intercept), matching historical behavior.
+  ///
+  /// When this value can change over time, also override [canPopListenable]
+  /// so the navigation stack rebuilds `PopScope`.
+  bool get canPop => false;
+
+  /// A [ListenableMixin] that triggers `PopScope` rebuilds when [canPop] may
+  /// have changed.
+  ///
+  /// Returns `null` when [canPop] is static (no reactive updates needed).
+  ///
+  /// In Flutter apps, convert a foundation `ValueNotifier` / `ChangeNotifier`
+  /// with `toListenableMixin()` from `package:zenrouter`:
+  ///
+  /// ```dart
+  /// final dirty = ValueNotifier(false);
+  ///
+  /// @override
+  /// ListenableMixin? get canPopListenable => dirty.toListenableMixin();
+  /// ```
+  ListenableMixin? get canPopListenable => null;
+
   /// Called when the route is about to be popped.
   ///
   /// Return `true` to allow the pop operation to proceed, or `false` to block it.

--- a/packages/zenrouter_core/lib/src/mixin/guard_rule.dart
+++ b/packages/zenrouter_core/lib/src/mixin/guard_rule.dart
@@ -67,8 +67,7 @@ mixin RouteGuardRule<T extends RouteTarget> on RouteTarget
   ListenableMixin? get canPopListenable {
     final listenables = <ListenableMixin>[
       for (final rule in guardRules)
-        if (rule.canPopListenable(this as T) case final listenable?)
-          listenable,
+        if (rule.canPopListenable(this as T) case final listenable?) listenable,
     ];
     return switch (listenables) {
       [] => null,

--- a/packages/zenrouter_core/lib/src/mixin/guard_rule.dart
+++ b/packages/zenrouter_core/lib/src/mixin/guard_rule.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+
+import 'package:zenrouter_core/src/coordinator/base.dart';
+import 'package:zenrouter_core/src/internal/reactive.dart';
+import 'package:zenrouter_core/src/mixin/guard.dart';
+import 'package:zenrouter_core/src/mixin/target.dart';
+
+/// Base class for composable pop-guard logic.
+///
+/// Guard rules extract leave-confirmation logic from routes into reusable,
+/// testable components. Rules are executed in order until one returns a
+/// non-null result.
+///
+/// ## Role in Navigation Flow
+///
+/// When a [RouteGuardRule] route is about to be popped:
+///
+/// 1. [RouteGuard.popGuardWith] iterates through [RouteGuardRule.guardRules]
+/// 2. Each rule's [guard] is called in sequence
+/// 3. Based on the result:
+///    - `null`: Next rule is processed
+///    - `false`: Pop is blocked, stack unchanged
+///    - `true`: Pop is allowed, chain stops
+/// 4. If every rule returns `null`, the pop is allowed
+///
+/// Rules can be composed for complex scenarios: unsaved-changes prompts,
+/// permission checks, logging, etc.
+abstract class GuardRule<T extends RouteTarget> {
+  const GuardRule();
+
+  /// Sync hint for [RouteGuard.canPop].
+  ///
+  /// Return `false` to force `PopScope` interception. Default `true` means
+  /// this rule does not require interception on its own.
+  /// [RouteGuardRule.canPop] is `true` only when every rule returns `true`.
+  bool canPop(covariant T route) => true;
+
+  /// Optional [ListenableMixin] that invalidates [canPop] for [route].
+  ListenableMixin? canPopListenable(covariant T route) => null;
+
+  /// Determines whether the pop should proceed for [route].
+  ///
+  /// Return `null` to continue to the next rule.
+  /// Return `true` to allow the pop (stops the chain).
+  /// Return `false` to block the pop (stops the chain).
+  FutureOr<bool?> guard(
+    covariant CoordinatorCore coordinator,
+    covariant T route,
+  );
+}
+
+/// Mixin for routes that use a list of guard rules.
+///
+/// Routes with this mixin delegate their pop-guard logic to a list of
+/// [GuardRule] instances, enabling composable and testable guard chains.
+mixin RouteGuardRule<T extends RouteTarget> on RouteTarget
+    implements RouteGuard {
+  /// The list of rules applied to this route, in order.
+  ///
+  /// Rules are processed sequentially. The first non-null result wins.
+  List<GuardRule> get guardRules;
+
+  @override
+  bool get canPop => guardRules.every((rule) => rule.canPop(this as T));
+
+  @override
+  ListenableMixin? get canPopListenable {
+    final listenables = <ListenableMixin>[
+      for (final rule in guardRules)
+        if (rule.canPopListenable(this as T) case final listenable?)
+          listenable,
+    ];
+    return switch (listenables) {
+      [] => null,
+      [final only] => only,
+      final many => ListenableMixin.merge(many),
+    };
+  }
+
+  // coverage:ignore-start
+  @override
+  FutureOr<bool> popGuard() => true;
+  // coverage:ignore-end
+
+  /// Implements [RouteGuard.popGuardWith] by running all rules in sequence.
+  ///
+  /// Processing stops when any rule returns a non-null [bool].
+  /// If all rules return `null`, the pop is allowed.
+  @override
+  FutureOr<bool> popGuardWith(covariant CoordinatorCore coordinator) async {
+    assert(stackPath?.coordinator == coordinator, '''
+[RouteGuard] The path [${stackPath.toString()}] is associated with a different coordinator (or null) than the one currently handling the navigation.
+Expected coordinator: $coordinator
+Path's coordinator: ${stackPath?.coordinator}
+Ensure that the path is created with the correct coordinator using `.createWith()` and that routes are being managed by the correct coordinator.
+''');
+
+    for (final rule in guardRules) {
+      final result = await rule.guard(coordinator, this as T);
+      if (result != null) return result;
+    }
+    return true;
+  }
+}

--- a/packages/zenrouter_core/lib/src/mixin/redirect.dart
+++ b/packages/zenrouter_core/lib/src/mixin/redirect.dart
@@ -46,10 +46,16 @@ mixin RouteRedirect<T extends RouteTarget> on RouteTarget {
 
       if (newTarget == target) break;
 
-      if (newTarget is T) {
+      if (newTarget is! T) {
         target.onDiscard();
-        target = newTarget;
+        throw StateError(
+          'RouteRedirect returned ${newTarget.runtimeType}, expected $T. '
+          'Redirect destinations must be the same route type as the source.',
+        );
       }
+
+      target.onDiscard();
+      target = newTarget;
     }
     return target;
   }

--- a/packages/zenrouter_core/lib/zenrouter_core.dart
+++ b/packages/zenrouter_core/lib/zenrouter_core.dart
@@ -1,6 +1,7 @@
 library;
 
 export 'src/internal/diff.dart';
+export 'src/internal/reactive.dart' show ListenableMixin, ListenableObject;
 
 export 'src/coordinator/base.dart';
 export 'src/coordinator/modular.dart';
@@ -11,6 +12,7 @@ export 'src/path/navigatable.dart';
 export 'src/mixin/uri.dart';
 export 'src/mixin/deeplink.dart';
 export 'src/mixin/guard.dart';
+export 'src/mixin/guard_rule.dart';
 export 'src/mixin/identity.dart';
 export 'src/mixin/layout.dart';
 export 'src/mixin/redirect.dart';

--- a/packages/zenrouter_core/test/mixin/guard_rule_test.dart
+++ b/packages/zenrouter_core/test/mixin/guard_rule_test.dart
@@ -49,16 +49,16 @@ void main() {
     });
 
     test('canPopListenable is null when no rules expose one', () {
-      final route = RuleGuardedRoute('1', rules: [const _FixedCanPopRule(true)]);
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _FixedCanPopRule(true)],
+      );
       expect(route.canPopListenable, isNull);
     });
 
     test('canPopListenable returns single listenable', () {
       final notifier = _TestListenable();
-      final route = RuleGuardedRoute(
-        '1',
-        rules: [_ListenableRule(notifier)],
-      );
+      final route = RuleGuardedRoute('1', rules: [_ListenableRule(notifier)]);
       expect(route.canPopListenable, same(notifier));
     });
 

--- a/packages/zenrouter_core/test/mixin/guard_rule_test.dart
+++ b/packages/zenrouter_core/test/mixin/guard_rule_test.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zenrouter_core/zenrouter_core.dart';
+
+class TestRoute extends RouteTarget {
+  TestRoute(this.id);
+  final String id;
+
+  @override
+  List<Object?> get props => [id];
+}
+
+class RuleGuardedRoute extends TestRoute with RouteGuardRule<TestRoute> {
+  RuleGuardedRoute(super.id, {required this.rules});
+
+  final List<GuardRule> rules;
+
+  @override
+  List<GuardRule> get guardRules => rules;
+}
+
+void main() {
+  group('RouteGuardRule', () {
+    test('popGuard defaults to true', () {
+      final route = RuleGuardedRoute('1', rules: []);
+      expect(route.popGuard(), isTrue);
+    });
+
+    test('implements RouteGuard', () {
+      final route = RuleGuardedRoute('1', rules: []);
+      expect(route, isA<RouteGuard>());
+    });
+
+    test('canPop is true when every rule allows', () {
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _FixedCanPopRule(true), const _FixedCanPopRule(true)],
+      );
+      expect(route.canPop, isTrue);
+    });
+
+    test('canPop is false when any rule requires intercept', () {
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _FixedCanPopRule(true), const _FixedCanPopRule(false)],
+      );
+      expect(route.canPop, isFalse);
+    });
+
+    test('canPopListenable is null when no rules expose one', () {
+      final route = RuleGuardedRoute('1', rules: [const _FixedCanPopRule(true)]);
+      expect(route.canPopListenable, isNull);
+    });
+
+    test('canPopListenable returns single listenable', () {
+      final notifier = _TestListenable();
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [_ListenableRule(notifier)],
+      );
+      expect(route.canPopListenable, same(notifier));
+    });
+
+    test('canPopListenable merges multiple listenables', () {
+      final a = _TestListenable();
+      final b = _TestListenable();
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [_ListenableRule(a), _ListenableRule(b)],
+      );
+      expect(route.canPopListenable, isA<ListenableMixin>());
+      expect(route.canPopListenable, isNot(same(a)));
+      expect(route.canPopListenable, isNot(same(b)));
+
+      var notified = 0;
+      route.canPopListenable!.addListener(() => notified++);
+      a.notify();
+      b.notify();
+      expect(notified, 2);
+    });
+  });
+}
+
+class _TestListenable implements ListenableMixin {
+  final _listeners = <void Function()>[];
+
+  @override
+  void addListener(void Function() listener) => _listeners.add(listener);
+
+  @override
+  void removeListener(void Function() listener) => _listeners.remove(listener);
+
+  void notify() {
+    for (final listener in List<void Function()>.of(_listeners)) {
+      listener();
+    }
+  }
+}
+
+class _FixedCanPopRule extends GuardRule<TestRoute> {
+  const _FixedCanPopRule(this._canPop);
+
+  final bool _canPop;
+
+  @override
+  bool canPop(covariant TestRoute route) => _canPop;
+
+  @override
+  FutureOr<bool?> guard(
+    covariant CoordinatorCore coordinator,
+    covariant TestRoute route,
+  ) => null;
+}
+
+class _ListenableRule extends GuardRule<TestRoute> {
+  _ListenableRule(this._listenable);
+
+  final ListenableMixin _listenable;
+
+  @override
+  ListenableMixin? canPopListenable(covariant TestRoute route) => _listenable;
+
+  @override
+  FutureOr<bool?> guard(
+    covariant CoordinatorCore coordinator,
+    covariant TestRoute route,
+  ) => null;
+}

--- a/packages/zenrouter_core/test/mixin/guard_test.dart
+++ b/packages/zenrouter_core/test/mixin/guard_test.dart
@@ -34,6 +34,12 @@ void main() {
       expect(defaultGuard.popGuard(), isTrue);
     });
 
+    test('canPop defaults to false', () {
+      final defaultGuard = _DefaultGuardRoute('default');
+      expect(defaultGuard.canPop, isFalse);
+      expect(defaultGuard.canPopListenable, isNull);
+    });
+
     test('popGuard returns configured value', () async {
       final allowRoute = TestGuardedRoute('1', allowPop: true);
       final denyRoute = TestGuardedRoute('2', allowPop: false);

--- a/packages/zenrouter_core/test/mixin/redirect_test.dart
+++ b/packages/zenrouter_core/test/mixin/redirect_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zenrouter_core/zenrouter_core.dart';
+
+class BaseRoute extends RouteTarget {
+  BaseRoute(this.id);
+  final String id;
+
+  @override
+  List<Object?> get props => [id];
+}
+
+/// Redirects to a [BaseRoute] that is not a [SpecificRedirectRoute].
+class SpecificRedirectRoute extends BaseRoute with RouteRedirect<BaseRoute> {
+  SpecificRedirectRoute(super.id, {required this.redirectToId});
+
+  final String redirectToId;
+  bool discarded = false;
+
+  @override
+  BaseRoute redirect() => BaseRoute(redirectToId);
+
+  @override
+  void onDiscard() {
+    discarded = true;
+    super.onDiscard();
+  }
+}
+
+void main() {
+  group('RouteRedirect.resolve', () {
+    test(
+      'throws StateError when redirect returns wrong type for resolve T',
+      () async {
+        final route = SpecificRedirectRoute('source', redirectToId: 'target');
+
+        // Resolve as SpecificRedirectRoute, but redirect() returns a plain
+        // BaseRoute — the new type-mismatch guard must throw instead of looping.
+        await expectLater(
+          () => RouteRedirect.resolve<SpecificRedirectRoute>(route, null),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              allOf(
+                contains('BaseRoute'),
+                contains('expected SpecificRedirectRoute'),
+              ),
+            ),
+          ),
+        );
+        expect(route.discarded, isTrue);
+      },
+    );
+
+    test('returns redirected route when types match', () async {
+      final route = SpecificRedirectRoute('source', redirectToId: 'target');
+
+      final result = await RouteRedirect.resolve<BaseRoute>(route, null);
+
+      expect(result, isA<BaseRoute>());
+      expect(result!.id, 'target');
+      expect(route.discarded, isTrue);
+    });
+  });
+}

--- a/skills/zenrouter/ADVANCED.md
+++ b/skills/zenrouter/ADVANCED.md
@@ -253,6 +253,73 @@ class ShopIndexRoute extends AppRoute with RouteRedirectRule<AppRoute> {
 
 ---
 
+## GuardRule
+
+Composable pop guards applied via `RouteGuardRule<T>` mixin on a route.
+
+### Writing a rule
+
+```dart
+class UnsavedChangesRule extends GuardRule<AppRoute> {
+  @override
+  bool canPop(AppRoute route) =>
+      route is! EditableRoute || !route.hasUnsavedChanges;
+
+  @override
+  ListenableMixin? canPopListenable(AppRoute route) =>
+      route is EditableRoute ? route.dirty.toListenableMixin() : null;
+
+  @override
+  Future<bool?> guard(
+    covariant AppCoordinator coordinator,
+    AppRoute route,
+  ) async {
+    if (route is! EditableRoute || !route.hasUnsavedChanges) {
+      return null; // not applicable — next rule
+    }
+    return showDiscardDialog(coordinator.context); // true allow / false block
+  }
+}
+```
+
+| `bool?` (async `guard`) | Meaning |
+|:------------------------|:--------|
+| `null` | Pass to next rule |
+| `true` | Allow pop; stops chain |
+| `false` | Block pop; stops chain |
+
+| Sync `canPop` | Meaning |
+|:--------------|:--------|
+| `true` (default) | This rule does not force intercept |
+| `false` | Force `PopScope` intercept |
+
+Rules are evaluated in list order; first non-`null` `guard` result wins. If every rule returns `null`, the pop is allowed. `RouteGuardRule.canPop` is `true` only when every rule's `canPop` is `true`.
+
+### Applying rules to a route
+
+```dart
+class EditorRoute extends AppRoute with RouteGuardRule<AppRoute> {
+  @override
+  Uri toUri() => Uri.parse('/editor');
+
+  @override
+  Widget build(covariant AppCoordinator coordinator, BuildContext context) =>
+      const SizedBox.shrink();
+
+  @override
+  List<GuardRule<AppRoute>> get guardRules => [
+    UnsavedChangesRule(),
+    ConfirmLeaveRule(),
+  ];
+}
+```
+
+Full multi-rule sample (upload + unsaved + audit + reactive `canPop`):
+[`example/lib/main_guard_rules.dart`](../../packages/zenrouter/example/lib/main_guard_rules.dart)
+· [recipe](../../packages/zenrouter/doc/recipes/route-guard-rules.md)
+
+---
+
 ## IndexedStackPath (Tab Navigation)
 
 For tab-bar style navigation where all tabs stay alive:

--- a/skills/zenrouter/MIXIN.md
+++ b/skills/zenrouter/MIXIN.md
@@ -18,6 +18,7 @@ RouteTarget (base class)
 │       │       └── RouteLayout<T>       ← shell/tab layout (implements RouteLayoutParent)
 │       └── RouteLayoutParent            ← resolves StackPath for child routes
 ├── RouteGuard                           ← blocks pop
+├── RouteGuardRule<T>                    ← composable pop-guard chain
 ├── RouteRedirect<T>                     ← redirects before display
 ├── RouteRedirectRule<T>                 ← composable redirect chain
 └── RouteRestorable<T>                   ← state restoration after process death
@@ -90,15 +91,30 @@ Intercepts pop operations so you can block or confirm navigation away.
 
 ```dart
 mixin RouteGuard on RouteTarget {
+  bool get canPop;                                    // PopScope.canPop (default false)
+  ListenableMixin? get canPopListenable;              // reactive canPop invalidation
   FutureOr<bool> popGuard();                              // return false to block pop
   FutureOr<bool> popGuardWith(CoordinatorCore coordinator); // same, with coordinator access
 }
 ```
 
-**Example — confirmation dialog:**
+- `canPop: true` → platform pops freely (no `popGuard` for that gesture).
+- `canPop: false` → intercept, then `popGuard` decides.
+- Programmatic `pop` always consults `popGuard`.
+- Set `canPopListenable` (e.g. `dirty.toListenableMixin()` on a Flutter `ValueNotifier` / `ChangeNotifier`) so `PopScope` updates when state changes.
+
+**Example — reactive unsaved changes:**
 
 ```dart
 class EditRoute extends AppRoute with RouteGuard {
+  final dirty = ValueNotifier(false);
+
+  @override
+  ListenableMixin? get canPopListenable => dirty.toListenableMixin();
+
+  @override
+  bool get canPop => !dirty.value;
+
   @override
   Future<bool> popGuardWith(covariant AppCoordinator coordinator) async {
     return await showDialog<bool>(
@@ -114,6 +130,39 @@ class EditRoute extends AppRoute with RouteGuard {
   }
 }
 ```
+
+---
+
+### RouteGuardRule\<T\>
+
+**Package:** `zenrouter_core` · **Applies to:** `RouteTarget` (implements `RouteGuard`)
+
+Delegates pop-guard logic to a composable list of `GuardRule<T>` objects. See [ADVANCED.md — GuardRule](./ADVANCED.md#guardrule) for full details.
+
+```dart
+mixin RouteGuardRule<T extends RouteTarget> on RouteTarget implements RouteGuard {
+  List<GuardRule> get guardRules;
+}
+```
+
+Rules are evaluated in order. Each returns a `bool?`:
+
+| Result | Meaning |
+|:-------|:--------|
+| `null` | Pass to next rule |
+| `true` | Allow pop; stops chain |
+| `false` | Block pop; stops chain |
+
+If every rule returns `null` (or the list is empty), the pop is allowed.
+
+Sync [canPop](./MIXIN.md#routeguard) composition:
+
+| API | Meaning |
+|:----|:--------|
+| `GuardRule.canPop(route)` | `false` forces intercept; default `true` |
+| `RouteGuardRule.canPop` | `true` only if every rule returns `true` |
+| `GuardRule.canPopListenable(route)` | Optional `ListenableMixin` |
+| `RouteGuardRule.canPopListenable` | Single listenable, or `ListenableMixin.merge` |
 
 ---
 
@@ -384,6 +433,7 @@ void defineConverter() {
 | `RouteLayoutChild` | core | `RouteTarget` | Declares parent layout |
 | `RouteLayoutParent<T>` | core | `RouteLayoutChild` | Manages child StackPath |
 | `RouteGuard` | core | `RouteTarget` | Blocks pop |
+| `RouteGuardRule<T>` | core | `RouteTarget` | Composable pop-guard chain |
 | `RouteRedirect<T>` | core | `RouteTarget` | Simple redirect |
 | `RouteRedirectRule<T>` | core | `RouteTarget` | Composable redirect chain |
 | `RouteDeepLink` | core | `RouteUri` | Deep link strategy |

--- a/skills/zenrouter/SKILL.md
+++ b/skills/zenrouter/SKILL.md
@@ -6,9 +6,9 @@ description: >
   redirect rule, redirect guard, nested coordinator, or navigate programmatically.
   Triggers on: route, router, routing, coordinator, CoordinatorModular, RouteModule,
   NavigationPath, IndexedStackPath, RouteLayout, RouteRedirectRule, RedirectRule,
-  RedirectResult, parseRouteFromUri, push, pop, replace, navigate, deep link,
-  toUri, parentLayoutKey, layoutKey, bindLayout, RouteUnique, RouteGuard,
-  RouteRedirect, notFoundRoute, zenrouter.
+  RedirectResult, RouteGuardRule, GuardRule, parseRouteFromUri, push, pop, replace,
+  navigate, deep link, toUri, parentLayoutKey, layoutKey, bindLayout, RouteUnique,
+  RouteGuard, RouteRedirect, notFoundRoute, zenrouter.
 ---
 
 # ZenRouter Skill
@@ -23,8 +23,8 @@ feature organisation.
 >
 > | File | When to read |
 > |:-----|:-------------|
-> | [ADVANCED.md](./ADVANCED.md) | Coordinator-as-Module, tab navigation, composable redirect rules, parameter route examples |
-> | [MIXIN.md](./MIXIN.md) | Full reference for `RouteGuard`, `RouteRedirect`, `RouteDeepLink`, `RouteTransition`, `RouteQueryParameters`, `RouteRestorable` |
+> | [ADVANCED.md](./ADVANCED.md) | Coordinator-as-Module, tab navigation, composable redirect/guard rules, parameter route examples |
+> | [MIXIN.md](./MIXIN.md) | Full reference for `RouteGuard`, `RouteGuardRule`, `RouteRedirect`, `RouteDeepLink`, `RouteTransition`, `RouteQueryParameters`, `RouteRestorable` |
 > | [NAVIGATION.md](./NAVIGATION.md) | When to use `push` vs `navigate` vs `replace` and other navigation methods |
 
 ---
@@ -42,7 +42,9 @@ feature organisation.
 | `IndexedStackPath<T>` | `zenrouter` | Fixed set of routes for tab-bar style navigation |
 | `RouteLayout<T>` | `zenrouter` | Mixin — layout route that wraps nested routes (shell, tab bar, drawer, etc.) |
 | `RouteRedirectRule<T>` | `zenrouter_core` | Mixin — delegates redirect logic to a list of `RedirectRule`s |
-| `RedirectRule<T>` | `zenrouter_core` | Single composable guard; returns `continueRedirect`, `redirectTo`, or `stop` |
+| `RedirectRule<T>` | `zenrouter_core` | Single composable redirect; returns `continueRedirect`, `redirectTo`, or `stop` |
+| `RouteGuardRule<T>` | `zenrouter_core` | Mixin — delegates pop-guard logic to a list of `GuardRule`s |
+| `GuardRule<T>` | `zenrouter_core` | Single composable pop guard; returns `null` / `true` / `false` |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **`RouteGuardRule` / `GuardRule`** — a composable, reusable leave-confirmation API modeled after `RouteRedirectRule`. Routes declare a chain of guard rules instead of inlining `popGuard`, and Flutter `PopScope` can reactively free system/predictive back when leave is safe.

This also extends **`RouteGuard`** with sync `canPop` / `canPopListenable`, wires reactive `PopScope` rebuilds in `NavigationStack`, and includes related correctness fixes around redirect typing and `CoordinatorCore.pop`.

### Motivation

Today, leave checks (unsaved edits, upload-in-progress, confirm dialogs) are typically copy-pasted into each route’s `popGuard`. That is hard to reuse, hard to unit-test, and forces `PopScope.canPop: false` for every guarded route — blocking predictive back even when the form is clean.

`RouteGuardRule` mirrors the redirect-rule pattern:

| Concern | Redirect API | Guard API (new) |
|---------|--------------|-----------------|
| Single-route logic | `RouteRedirect` | `RouteGuard` |
| Reusable chain | `RouteRedirectRule` + `RedirectRule` | **`RouteGuardRule` + `GuardRule`** |
| Chain result | first non-null target | first non-null `bool` |

### What’s new

#### `GuardRule` / `RouteGuardRule` (`zenrouter_core`)

```dart
abstract class GuardRule<T extends RouteTarget> {
  bool canPop(covariant T route);                    // default true
  ListenableMixin? canPopListenable(covariant T route);
  FutureOr<bool?> guard(CoordinatorCore c, covariant T route);
}

mixin RouteGuardRule<T extends RouteTarget> on RouteTarget implements RouteGuard {
  List<GuardRule> get guardRules;
  // canPop / canPopListenable derived from rules
  // popGuardWith runs the chain (first non-null wins)
}
```

| `guard` returns | Meaning |
|-----------------|---------|
| `null` | Continue to next rule |
| `true` | Allow pop; stop chain |
| `false` | Block pop; stop chain |

Empty list / all-`null` → pop **allowed**.

`RouteGuardRule.canPop` is `true` only when **every** rule returns `canPop == true`. Multiple listenables are merged via `ListenableMixin.merge`.

#### Reactive `RouteGuard.canPop` / `canPopListenable`

- `canPop` maps to Flutter `PopScope.canPop` (default `false` — preserves historical intercept-always behavior).
- `canPopListenable` lets the stack rebuild `PopScope` when dirty/uploading flips, without recreating the page.
- Programmatic `pop()` still always consults `popGuard` / `popGuardWith`, even when `canPop` is `true`.

#### Flutter bridge (`zenrouter`)

- `toListenableMixin()` / `toFlutterListenable()` adapters between foundation `Listenable` and core `ListenableMixin`.
- `NavigationStack` wraps guarded pages in `ListenableBuilder` when a listenable is present, so system back updates live.

#### Docs & example

- Recipe: [`packages/zenrouter/doc/recipes/route-guard-rules.md`](packages/zenrouter/doc/recipes/route-guard-rules.md)
- Runnable sample: `flutter run -t lib/main_guard_rules.dart` in `packages/zenrouter/example`
- API / skills updated (`mixins.md`, `ADVANCED.md`, `MIXIN.md`, `SKILL.md`)

### Related fixes bundled in this PR

- **`CoordinatorCore.pop`**: pops only the nearest eligible stack (no longer multi-path in one call).
- **`RouteRedirect.resolve`**: throws `StateError` if a redirect returns a different route type (was previously silently ignored).
- **Deeplink `recover` / `navigate`**: documented / left intentionally un-awaited so callers do not hang on push futures that complete on pop.

### Example

```dart
class UnsavedChangesRule extends GuardRule<AppRoute> {
  @override
  bool canPop(AppRoute route) =>
      route is! EditableRoute || !route.hasUnsavedChanges;

  @override
  ListenableMixin? canPopListenable(AppRoute route) =>
      route is EditableRoute ? route.dirty.toListenableMixin() : null;

  @override
  Future<bool?> guard(covariant Coordinator c, AppRoute route) async {
    if (route is! EditableRoute || !route.hasUnsavedChanges) return null;
    return showDiscardDialog(c.navigator.context);
  }
}

class UploadRoute extends AppRoute
    with EditableRoute, UploadableRoute, RouteGuardRule<AppRoute> {
  @override
  List<GuardRule> get guardRules => const [
    GuardAuditRule(),
    UploadInProgressRule(), // hard blocker first
    UnsavedChangesRule(),
  ];
}
```

## Test plan

- [ ] `cd packages/zenrouter_core && dart test test/mixin/guard_rule_test.dart test/mixin/guard_test.dart test/mixin/redirect_test.dart`
- [ ] `cd packages/zenrouter && flutter test test/mixin/guard_rule_test.dart test/mixin/guard_test.dart test/stack/route_completion_test.dart`
- [ ] Run example: `cd packages/zenrouter/example && flutter run -t lib/main_guard_rules.dart`
  - [ ] Clean editable route → system back pops freely (`canPop == true`)
  - [ ] Dirty form → intercept → discard dialog; cancel keeps route, confirm pops
  - [ ] Upload-in-progress rule blocks before unsaved-changes rule when both apply
  - [ ] After clearing dirty / finishing upload, predictive/system back becomes free again via `canPopListenable`
- [ ] Programmatic `coordinator.pop()` still runs the guard chain when `canPop` is `true`
- [ ] Confirm redirect type mismatch throws (new `redirect_test.dart`)
- [ ] Nested stacks: `pop()` only affects the nearest eligible path


Made with [Cursor](https://cursor.com)