### PR TITLE
feat(guard)!: coordinator-optional GuardRule API (breaking)

### DIFF
--- a/packages/zenrouter/CHANGELOG.md
+++ b/packages/zenrouter/CHANGELOG.md
@@ -1,3 +1,48 @@
+## 2.3.0
+
+### ⚠️ Breaking Changes
+
+- **`GuardRule` contract renamed** (via `zenrouter_core` 2.2.0). The 2.1.0 / 2.2.0 methods are removed:
+
+  | Removed | Replacement |
+  |---------|-------------|
+  | `canPop(route)` | `canPopRule(route)` / `canPopRuleWith(coordinator, route)` |
+  | `canPopListenable(route)` | `canPopListenableRule(route)` / `canPopListenableRuleWith(coordinator, route)` |
+  | `guard(coordinator, route)` | `guardRule(route)` / `guardRuleWith(coordinator, route)` |
+
+  Use route-only methods when no coordinator is needed; override `*With` for dialogs / app state. Each `*With` defaults to its non-`With` counterpart.
+
+  ```dart
+  // Before
+  class UnsavedChangesRule extends GuardRule<AppRoute> {
+    @override
+    bool canPop(AppRoute route) => !route.hasUnsavedChanges;
+
+    @override
+    FutureOr<bool?> guard(Coordinator c, AppRoute route) async =>
+        showDiscardDialog(c.navigator.context);
+  }
+
+  // After
+  class UnsavedChangesRule extends GuardRule<AppRoute> {
+    @override
+    bool canPopRule(AppRoute route) => !route.hasUnsavedChanges;
+
+    @override
+    FutureOr<bool?> guardRuleWith(Coordinator c, AppRoute route) async =>
+        showDiscardDialog(c.navigator.context);
+  }
+  ```
+
+### 🚀 New Features
+
+- **`RouteGuard.canPopWith` / `canPopListenableWith`**: Coordinator-aware PopScope hints; `NavigationStack` prefers these when a coordinator is present.
+- **`RouteGuardRule.popGuard`**: Runs the `guardRule` chain without a coordinator.
+
+### 📖 Documentation
+
+- Recipe / example / mixins API updated for the dual `guardRule` / `guardRuleWith` API.
+
 ## 2.2.0
 
 ### 🚀 New Features

--- a/packages/zenrouter/doc/api/mixins.md
+++ b/packages/zenrouter/doc/api/mixins.md
@@ -284,9 +284,11 @@ Use this mixin when you need to protect forms with unsaved changes, prevent inte
 mixin RouteGuard on RouteTarget {
   // PopScope.canPop — true = free pop, false = intercept then popGuard (default false)
   bool get canPop;
+  bool canPopWith(covariant CoordinatorCore coordinator); // defaults to canPop
 
   // ListenableMixin so PopScope rebuilds when canPop changes
   ListenableMixin? get canPopListenable;
+  ListenableMixin? canPopListenableWith(covariant CoordinatorCore coordinator);
 
   // Return true to allow pop, false to prevent
   FutureOr<bool> popGuard();
@@ -425,10 +427,19 @@ Enables composable, reusable pop-guard logic by chaining multiple `GuardRule` in
 ```dart
 // Base class for creating guard rules
 abstract class GuardRule<T extends RouteTarget> {
-  bool canPop(covariant T route); // default true
-  ListenableMixin? canPopListenable(covariant T route);
-  FutureOr<bool?> guard(
-    covariant Coordinator coordinator,
+  // Non-coordinator (route-only)
+  bool canPopRule(covariant T route); // default true
+  ListenableMixin? canPopListenableRule(covariant T route);
+  FutureOr<bool?> guardRule(covariant T route); // default null
+
+  // Coordinator-aware (defaults to the non-With methods)
+  bool canPopRuleWith(CoordinatorCore coordinator, covariant T route);
+  ListenableMixin? canPopListenableRuleWith(
+    CoordinatorCore coordinator,
+    covariant T route,
+  );
+  FutureOr<bool?> guardRuleWith(
+    CoordinatorCore coordinator,
     covariant T route,
   );
 }
@@ -438,8 +449,8 @@ mixin RouteGuardRule<T extends RouteTarget> on RouteTarget
     implements RouteGuard {
   List<GuardRule> get guardRules;
 
-  // canPop / canPopListenable derived from rules
-  // Automatically implements RouteGuard.popGuardWith()
+  // canPop / canPopListenable / popGuard → non-With rule methods
+  // canPopWith / canPopListenableWith / popGuardWith → With rule methods
 }
 ```
 
@@ -451,20 +462,22 @@ mixin RouteGuardRule<T extends RouteTarget> on RouteTarget
 
 If every rule returns `null` (or the list is empty), the pop is allowed.
 
+Override `guardRule` when the decision only needs the route. Override `guardRuleWith` when you need a coordinator (dialogs, shared app state).
+
 #### Example: Unsaved Changes Rule
 
 ```dart
 class UnsavedChangesRule extends GuardRule<AppRoute> {
   @override
-  bool canPop(AppRoute route) =>
+  bool canPopRule(AppRoute route) =>
       route is! EditableRoute || !route.hasUnsavedChanges;
 
   @override
-  ListenableMixin? canPopListenable(AppRoute route) =>
+  ListenableMixin? canPopListenableRule(AppRoute route) =>
       route is EditableRoute ? route.dirty.toListenableMixin() : null;
 
   @override
-  FutureOr<bool?> guard(
+  FutureOr<bool?> guardRuleWith(
     Coordinator coordinator,
     AppRoute route,
   ) async {

--- a/packages/zenrouter/doc/recipes/route-guard-rules.md
+++ b/packages/zenrouter/doc/recipes/route-guard-rules.md
@@ -46,15 +46,18 @@ Highlights from that file:
 ```dart
 class UnsavedChangesRule extends GuardRule<AppRoute> {
   @override
-  bool canPop(AppRoute route) =>
+  bool canPopRule(AppRoute route) =>
       route is! EditableRoute || !route.hasUnsavedChanges;
 
   @override
-  ListenableMixin? canPopListenable(AppRoute route) =>
+  ListenableMixin? canPopListenableRule(AppRoute route) =>
       route is EditableRoute ? route.dirty.toListenableMixin() : null;
 
   @override
-  Future<bool?> guard(covariant GuardRulesCoordinator c, AppRoute route) async {
+  Future<bool?> guardRuleWith(
+    covariant GuardRulesCoordinator c,
+    AppRoute route,
+  ) async {
     if (route is! EditableRoute || !route.hasUnsavedChanges) return null;
     return showDiscardDialog(c.navigator.context);
   }
@@ -81,12 +84,12 @@ class UploadRoute extends AppRoute
 
 | Sync API | Meaning |
 |----------|---------|
-| `canPop → true` | This rule does not force `PopScope` intercept |
-| `canPop → false` | Force intercept; then run `guard` |
-| `canPopListenable` | Rebuild `PopScope` when dirty/uploading flips |
+| `canPopRule → true` | This rule does not force `PopScope` intercept |
+| `canPopRule → false` | Force intercept; then run `guardRule` / `guardRuleWith` |
+| `canPopListenableRule` | Rebuild `PopScope` when dirty/uploading flips |
 | Empty / all-`null` guards | Pop is **allowed** |
 
-`RouteGuardRule.canPop` is `true` only when **every** rule returns `canPop == true`.
+`RouteGuardRule.canPop` is `true` only when **every** rule returns `canPopRule == true`.
 `canPopListenable` merges all rule listenables via `ListenableMixin.merge`.
 
 ### Example walkthrough — `UploadRoute`
@@ -108,12 +111,9 @@ test('UnsavedChangesRule continues when route is not editable', () async {
   final rule = const UnsavedChangesRule();
   final route = HomeRoute(); // not EditableRoute
 
-  expect(rule.canPop(route), isTrue);
-  expect(rule.canPopListenable(route), isNull);
-  expect(
-    await rule.guard(_FakeCoordinator(), route),
-    isNull,
-  );
+  expect(rule.canPopRule(route), isTrue);
+  expect(rule.canPopListenableRule(route), isNull);
+  expect(await rule.guardRule(route), isNull);
 });
 
 test('UnsavedChangesRule blocks when dirty and dialog declines', () async {
@@ -124,14 +124,15 @@ test('UnsavedChangesRule blocks when dirty and dialog declines', () async {
 ## Common gotchas
 
 1. **Order matters** — put cheap / hard blockers first (upload), soft prompts later (unsaved).
-2. **`canPop` vs `popGuard`** — programmatic `coordinator.pop()` always runs `guard`, even when `canPop` is `true`.
+2. **`canPop` vs `popGuard`** — programmatic `coordinator.pop()` always runs `guardRuleWith`, even when `canPop` is `true`.
 3. **Use `toListenableMixin()`** — Flutter `ValueNotifier` is not a `ListenableMixin`; wrap it:
    ```dart
    dirty.toListenableMixin()
    ```
-4. **Rebuild PopScope** — without `canPopListenable`, flipping dirty will not update system-back behavior until the page is rebuilt.
+4. **Rebuild PopScope** — without `canPopListenable` / `canPopListenableRule`, flipping dirty will not update system-back behavior until the page is rebuilt.
 5. **Don’t put `RouteGuard` on login-only flows that should never intercept** — or override `canPop => true` and return `true` from `guard`.
 6. **Entry protection is redirect, not guard** — auth “can I open this?” belongs in `RouteRedirect` / `RedirectRule`.
+7. **Coordinator-optional rules** — override `guardRule` for route-only checks; override `guardRuleWith` when you need navigator context or app state.
 
 ## When to use what
 

--- a/packages/zenrouter/example/lib/main_guard_rules.dart
+++ b/packages/zenrouter/example/lib/main_guard_rules.dart
@@ -153,19 +153,19 @@ class UnsavedChangesRule extends GuardRule<AppRoute> {
   const UnsavedChangesRule();
 
   @override
-  bool canPop(AppRoute route) {
+  bool canPopRule(AppRoute route) {
     if (route is! EditableRoute) return true;
     return !route.hasUnsavedChanges;
   }
 
   @override
-  ListenableMixin? canPopListenable(AppRoute route) {
+  ListenableMixin? canPopListenableRule(AppRoute route) {
     if (route is! EditableRoute) return null;
     return route.dirty.toListenableMixin();
   }
 
   @override
-  Future<bool?> guard(
+  Future<bool?> guardRuleWith(
     covariant GuardRulesCoordinator coordinator,
     AppRoute route,
   ) async {
@@ -181,19 +181,19 @@ class UploadInProgressRule extends GuardRule<AppRoute> {
   const UploadInProgressRule();
 
   @override
-  bool canPop(AppRoute route) {
+  bool canPopRule(AppRoute route) {
     if (route is! UploadableRoute) return true;
     return !route.isUploading;
   }
 
   @override
-  ListenableMixin? canPopListenable(AppRoute route) {
+  ListenableMixin? canPopListenableRule(AppRoute route) {
     if (route is! UploadableRoute) return null;
     return route.uploading.toListenableMixin();
   }
 
   @override
-  Future<bool?> guard(
+  Future<bool?> guardRuleWith(
     covariant GuardRulesCoordinator coordinator,
     AppRoute route,
   ) async {
@@ -211,10 +211,10 @@ class ConfirmLeaveRule extends GuardRule<AppRoute> {
   const ConfirmLeaveRule();
 
   @override
-  bool canPop(AppRoute route) => false;
+  bool canPopRule(AppRoute route) => false;
 
   @override
-  Future<bool?> guard(
+  Future<bool?> guardRuleWith(
     covariant GuardRulesCoordinator coordinator,
     AppRoute route,
   ) async {
@@ -229,7 +229,7 @@ class GuardAuditRule extends GuardRule<AppRoute> {
   const GuardAuditRule();
 
   @override
-  Future<bool?> guard(
+  Future<bool?> guardRuleWith(
     covariant GuardRulesCoordinator coordinator,
     AppRoute route,
   ) async {

--- a/packages/zenrouter/lib/src/path/stack.dart
+++ b/packages/zenrouter/lib/src/path/stack.dart
@@ -205,12 +205,21 @@ class _NavigationStackState<T extends RouteTarget>
 
     if (guard == null) return buildScope(true);
 
-    final canPopListenable = guard.canPopListenable;
-    if (canPopListenable == null) return buildScope(guard.canPop);
+    final coordinator = widget.coordinator;
+    final canPopListenable = switch (coordinator) {
+      null => guard.canPopListenable,
+      final c => guard.canPopListenableWith(c),
+    };
+    bool resolveCanPop() => switch (coordinator) {
+      null => guard.canPop,
+      final c => guard.canPopWith(c),
+    };
+
+    if (canPopListenable == null) return buildScope(resolveCanPop());
 
     return ListenableBuilder(
       listenable: canPopListenable.toFlutterListenable(),
-      builder: (context, _) => buildScope(guard.canPop),
+      builder: (context, _) => buildScope(resolveCanPop()),
     );
   }
 

--- a/packages/zenrouter/pubspec.yaml
+++ b/packages/zenrouter/pubspec.yaml
@@ -2,7 +2,7 @@ name: zenrouter
 description: >-
   A powerful Flutter router with deep linking, web support, type-safe routing,
   guards, redirects, and zero boilerplate.
-version: 2.2.0
+version: 2.3.0
 
 repository: https://github.com/definev/zenrouter
 homepage: https://github.com/definev/zenrouter/tree/main/packages/zenrouter
@@ -30,7 +30,7 @@ dependencies:
   flutter:
     sdk: flutter
   collection: ^1.19.1
-  zenrouter_core: ^2.1.0
+  zenrouter_core: ^2.2.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/zenrouter/test/coordinator/navigation_test.dart
+++ b/packages/zenrouter/test/coordinator/navigation_test.dart
@@ -449,7 +449,7 @@ void main() {
       expect(coordinator.root.stack.last, home);
     });
 
-    test('returns false when stack cannot be popped (length 1)', () async {
+    test('returns null when stack cannot be popped (length 1)', () async {
       // Setup: Home only
       coordinator.push(HomeRoute());
       await Future.delayed(Duration.zero);
@@ -459,7 +459,7 @@ void main() {
       // tryPop should return false (nothing to pop)
       final result = await coordinator.tryPop();
 
-      expect(result, isFalse);
+      expect(result, isNull);
       expect(coordinator.root.stack.length, 1);
     });
   });

--- a/packages/zenrouter/test/mixin/guard_rule_test.dart
+++ b/packages/zenrouter/test/mixin/guard_rule_test.dart
@@ -291,7 +291,7 @@ class ContinueGuardRule extends GuardRule<GuardRuleTestRoute> {
   const ContinueGuardRule();
 
   @override
-  FutureOr<bool?> guard(
+  FutureOr<bool?> guardRuleWith(
     covariant Coordinator coordinator,
     covariant GuardRuleTestRoute route,
   ) => null;
@@ -301,7 +301,7 @@ class AllowGuardRule extends GuardRule<GuardRuleTestRoute> {
   const AllowGuardRule();
 
   @override
-  FutureOr<bool?> guard(
+  FutureOr<bool?> guardRuleWith(
     covariant Coordinator coordinator,
     covariant GuardRuleTestRoute route,
   ) => true;
@@ -311,7 +311,7 @@ class BlockGuardRule extends GuardRule<GuardRuleTestRoute> {
   const BlockGuardRule();
 
   @override
-  FutureOr<bool?> guard(
+  FutureOr<bool?> guardRuleWith(
     covariant Coordinator coordinator,
     covariant GuardRuleTestRoute route,
   ) => false;
@@ -324,7 +324,7 @@ class CountingGuardRule extends GuardRule<GuardRuleTestRoute> {
   int callCount = 0;
 
   @override
-  FutureOr<bool?> guard(
+  FutureOr<bool?> guardRuleWith(
     covariant Coordinator coordinator,
     covariant GuardRuleTestRoute route,
   ) {
@@ -340,7 +340,7 @@ class AsyncGuardRule extends GuardRule<GuardRuleTestRoute> {
   final Duration delay;
 
   @override
-  Future<bool?> guard(
+  Future<bool?> guardRuleWith(
     covariant Coordinator coordinator,
     covariant GuardRuleTestRoute route,
   ) async {

--- a/packages/zenrouter/test/path/mutatable_test.dart
+++ b/packages/zenrouter/test/path/mutatable_test.dart
@@ -807,8 +807,8 @@ void main() {
 
       final result = await coordinator.tryPop();
 
-      /// Cannot pop since the route stack is has only one element
-      expect(result, false);
+      /// Return null for pop since the route stack is has only one element
+      expect(result, null);
     });
 
     test('notifies listeners after successful pop', () async {

--- a/packages/zenrouter_core/CHANGELOG.md
+++ b/packages/zenrouter_core/CHANGELOG.md
@@ -1,3 +1,53 @@
+## 2.2.0
+
+### Breaking Changes
+
+- **`GuardRule` contract renamed** for coordinator-optional use. The 2.1.0 methods are removed:
+
+  | Removed (2.1.0) | Replacement |
+  |-----------------|-------------|
+  | `canPop(route)` | `canPopRule(route)` / `canPopRuleWith(coordinator, route)` |
+  | `canPopListenable(route)` | `canPopListenableRule(route)` / `canPopListenableRuleWith(coordinator, route)` |
+  | `guard(coordinator, route)` | `guardRule(route)` / `guardRuleWith(coordinator, route)` |
+
+  Migration:
+
+  ```dart
+  // Before (2.1.0)
+  class UnsavedChangesRule extends GuardRule<AppRoute> {
+    @override
+    bool canPop(AppRoute route) => !route.hasUnsavedChanges;
+
+    @override
+    FutureOr<bool?> guard(CoordinatorCore c, AppRoute route) async { /* ... */ }
+  }
+
+  // After (2.2.0) — route-only
+  class UnsavedChangesRule extends GuardRule<AppRoute> {
+    @override
+    bool canPopRule(AppRoute route) => !route.hasUnsavedChanges;
+
+    @override
+    FutureOr<bool?> guardRule(AppRoute route) async { /* ... */ }
+  }
+
+  // After (2.2.0) — needs coordinator (dialogs, app state)
+  class UnsavedChangesRule extends GuardRule<AppRoute> {
+    @override
+    bool canPopRule(AppRoute route) => !route.hasUnsavedChanges;
+
+    @override
+    FutureOr<bool?> guardRuleWith(CoordinatorCore c, AppRoute route) async { /* ... */ }
+  }
+  ```
+
+  Each `*With` method defaults to its non-`With` counterpart. `guardRule` defaults to `null` (continue chain).
+
+### New Features
+
+- **`RouteGuard.canPopWith` / `canPopListenableWith`**: Coordinator-aware PopScope hints (default to `canPop` / `canPopListenable`).
+- **`RouteGuardRule.popGuard`**: Now runs the `guardRule` chain (no coordinator), matching `popGuardWith` → `guardRuleWith`.
+
 ## 2.1.0
 
 ### New Features

--- a/packages/zenrouter_core/lib/src/coordinator/base.dart
+++ b/packages/zenrouter_core/lib/src/coordinator/base.dart
@@ -435,8 +435,8 @@ abstract class CoordinatorCore<T extends RouteUri> extends Equatable
         return await path.pop(result);
       }
     }
-
-    return false;
+    
+    return null;
   }
 
   /// Triggers a rebuild of the coordinator.

--- a/packages/zenrouter_core/lib/src/coordinator/base.dart
+++ b/packages/zenrouter_core/lib/src/coordinator/base.dart
@@ -435,7 +435,7 @@ abstract class CoordinatorCore<T extends RouteUri> extends Equatable
         return await path.pop(result);
       }
     }
-    
+
     return null;
   }
 

--- a/packages/zenrouter_core/lib/src/mixin/guard.dart
+++ b/packages/zenrouter_core/lib/src/mixin/guard.dart
@@ -47,6 +47,12 @@ mixin RouteGuard on RouteTarget {
   /// so the navigation stack rebuilds `PopScope`.
   bool get canPop => false;
 
+  /// Coordinator-aware variant of [canPop].
+  ///
+  /// Defaults to [canPop]. Override when the sync pop hint depends on
+  /// coordinator state.
+  bool canPopWith(covariant CoordinatorCore coordinator) => canPop;
+
   /// A [ListenableMixin] that triggers `PopScope` rebuilds when [canPop] may
   /// have changed.
   ///
@@ -62,6 +68,13 @@ mixin RouteGuard on RouteTarget {
   /// ListenableMixin? get canPopListenable => dirty.toListenableMixin();
   /// ```
   ListenableMixin? get canPopListenable => null;
+
+  /// Coordinator-aware variant of [canPopListenable].
+  ///
+  /// Defaults to [canPopListenable].
+  ListenableMixin? canPopListenableWith(
+    covariant CoordinatorCore coordinator,
+  ) => canPopListenable;
 
   /// Called when the route is about to be popped.
   ///

--- a/packages/zenrouter_core/lib/src/mixin/guard_rule.dart
+++ b/packages/zenrouter_core/lib/src/mixin/guard_rule.dart
@@ -4,7 +4,6 @@ import 'package:zenrouter_core/src/coordinator/base.dart';
 import 'package:zenrouter_core/src/internal/reactive.dart';
 import 'package:zenrouter_core/src/mixin/guard.dart';
 import 'package:zenrouter_core/src/mixin/target.dart';
-import 'package:zenrouter_core/src/mixin/uri.dart';
 
 /// Base class for composable pop-guard logic.
 ///
@@ -107,7 +106,7 @@ mixin RouteGuardRule<T extends RouteTarget> on RouteTarget
   bool get canPop => guardRules.every((rule) => rule.canPopRule(this as T));
 
   @override
-  bool canPopWith(covariant CoordinatorCore<RouteUri> coordinator) =>
+  bool canPopWith(covariant CoordinatorCore coordinator) =>
       guardRules.every((rule) => rule.canPopRuleWith(coordinator, this as T));
 
   @override
@@ -125,9 +124,7 @@ mixin RouteGuardRule<T extends RouteTarget> on RouteTarget
   }
 
   @override
-  ListenableMixin? canPopListenableWith(
-    covariant CoordinatorCore<RouteUri> coordinator,
-  ) {
+  ListenableMixin? canPopListenableWith(covariant CoordinatorCore coordinator) {
     final listenables = <ListenableMixin>[
       for (final rule in guardRules)
         if (rule.canPopListenableRuleWith(coordinator, this as T)

--- a/packages/zenrouter_core/lib/src/mixin/guard_rule.dart
+++ b/packages/zenrouter_core/lib/src/mixin/guard_rule.dart
@@ -4,6 +4,7 @@ import 'package:zenrouter_core/src/coordinator/base.dart';
 import 'package:zenrouter_core/src/internal/reactive.dart';
 import 'package:zenrouter_core/src/mixin/guard.dart';
 import 'package:zenrouter_core/src/mixin/target.dart';
+import 'package:zenrouter_core/src/mixin/uri.dart';
 
 /// Base class for composable pop-guard logic.
 ///
@@ -11,12 +12,22 @@ import 'package:zenrouter_core/src/mixin/target.dart';
 /// testable components. Rules are executed in order until one returns a
 /// non-null result.
 ///
+/// ## Coordinator vs non-coordinator
+///
+/// Prefer the non-`With` methods when the rule only needs the [route]:
+/// [canPopRule], [canPopListenableRule], [guardRule].
+///
+/// Override the `With` variants when the decision needs a
+/// [CoordinatorCore] (dialogs via navigator context, shared app state, etc.).
+/// By default, each `With` method delegates to its non-`With` counterpart.
+///
 /// ## Role in Navigation Flow
 ///
 /// When a [RouteGuardRule] route is about to be popped:
 ///
-/// 1. [RouteGuard.popGuardWith] iterates through [RouteGuardRule.guardRules]
-/// 2. Each rule's [guard] is called in sequence
+/// 1. [RouteGuard.popGuard] / [RouteGuard.popGuardWith] iterates through
+///    [RouteGuardRule.guardRules]
+/// 2. Each rule's [guardRule] / [guardRuleWith] is called in sequence
 /// 3. Based on the result:
 ///    - `null`: Next rule is processed
 ///    - `false`: Pop is blocked, stack unchanged
@@ -28,31 +39,63 @@ import 'package:zenrouter_core/src/mixin/target.dart';
 abstract class GuardRule<T extends RouteTarget> {
   const GuardRule();
 
-  /// Sync hint for [RouteGuard.canPop].
+  /// Sync hint for [RouteGuard.canPop] when no coordinator is available.
   ///
   /// Return `false` to force `PopScope` interception. Default `true` means
   /// this rule does not require interception on its own.
   /// [RouteGuardRule.canPop] is `true` only when every rule returns `true`.
-  bool canPop(covariant T route) => true;
+  bool canPopRule(covariant T route) => true;
 
   /// Optional [ListenableMixin] that invalidates [canPop] for [route].
-  ListenableMixin? canPopListenable(covariant T route) => null;
+  ListenableMixin? canPopListenableRule(covariant T route) => null;
 
-  /// Determines whether the pop should proceed for [route].
+  /// Determines whether the pop should proceed for [route] without a
+  /// coordinator.
   ///
   /// Return `null` to continue to the next rule.
   /// Return `true` to allow the pop (stops the chain).
   /// Return `false` to block the pop (stops the chain).
-  FutureOr<bool?> guard(
+  ///
+  /// Defaults to `null` (no opinion) so rules that only override
+  /// [guardRuleWith] still continue correctly on the non-coordinator path.
+  FutureOr<bool?> guardRule(covariant T route) => null;
+
+  /// Sync hint for [RouteGuard.canPopWith].
+  ///
+  /// Defaults to [canPopRule].
+  bool canPopRuleWith(
     covariant CoordinatorCore coordinator,
     covariant T route,
-  );
+  ) => canPopRule(route);
+
+  /// Optional [ListenableMixin] for [RouteGuard.canPopListenableWith].
+  ///
+  /// Defaults to [canPopListenableRule].
+  ListenableMixin? canPopListenableRuleWith(
+    covariant CoordinatorCore coordinator,
+    covariant T route,
+  ) => canPopListenableRule(route);
+
+  /// Determines whether the pop should proceed for [route] with [coordinator].
+  ///
+  /// Return `null` to continue to the next rule.
+  /// Return `true` to allow the pop (stops the chain).
+  /// Return `false` to block the pop (stops the chain).
+  ///
+  /// Defaults to [guardRule].
+  FutureOr<bool?> guardRuleWith(
+    covariant CoordinatorCore coordinator,
+    covariant T route,
+  ) => guardRule(route);
 }
 
 /// Mixin for routes that use a list of guard rules.
 ///
 /// Routes with this mixin delegate their pop-guard logic to a list of
 /// [GuardRule] instances, enabling composable and testable guard chains.
+///
+/// Non-coordinator APIs ([canPop], [canPopListenable], [popGuard]) call the
+/// non-`With` rule methods. Coordinator-aware APIs call the `With` variants.
 mixin RouteGuardRule<T extends RouteTarget> on RouteTarget
     implements RouteGuard {
   /// The list of rules applied to this route, in order.
@@ -61,25 +104,51 @@ mixin RouteGuardRule<T extends RouteTarget> on RouteTarget
   List<GuardRule> get guardRules;
 
   @override
-  bool get canPop => guardRules.every((rule) => rule.canPop(this as T));
+  bool get canPop => guardRules.every((rule) => rule.canPopRule(this as T));
+
+  @override
+  bool canPopWith(covariant CoordinatorCore<RouteUri> coordinator) =>
+      guardRules.every((rule) => rule.canPopRuleWith(coordinator, this as T));
 
   @override
   ListenableMixin? get canPopListenable {
     final listenables = <ListenableMixin>[
       for (final rule in guardRules)
-        if (rule.canPopListenable(this as T) case final listenable?) listenable,
+        if (rule.canPopListenableRule(this as T) case final listenable?)
+          listenable,
     ];
     return switch (listenables) {
       [] => null,
       [final only] => only,
-      final many => ListenableMixin.merge(many),
+      _ => ListenableMixin.merge(listenables),
     };
   }
 
-  // coverage:ignore-start
   @override
-  FutureOr<bool> popGuard() => true;
-  // coverage:ignore-end
+  ListenableMixin? canPopListenableWith(
+    covariant CoordinatorCore<RouteUri> coordinator,
+  ) {
+    final listenables = <ListenableMixin>[
+      for (final rule in guardRules)
+        if (rule.canPopListenableRuleWith(coordinator, this as T)
+            case final listenable?)
+          listenable,
+    ];
+    return switch (listenables) {
+      [] => null,
+      [final only] => only,
+      _ => ListenableMixin.merge(listenables),
+    };
+  }
+
+  @override
+  FutureOr<bool> popGuard() async {
+    for (final rule in guardRules) {
+      final result = await rule.guardRule(this as T);
+      if (result != null) return result;
+    }
+    return true;
+  }
 
   /// Implements [RouteGuard.popGuardWith] by running all rules in sequence.
   ///
@@ -95,7 +164,7 @@ Ensure that the path is created with the correct coordinator using `.createWith(
 ''');
 
     for (final rule in guardRules) {
-      final result = await rule.guard(coordinator, this as T);
+      final result = await rule.guardRuleWith(coordinator, this as T);
       if (result != null) return result;
     }
     return true;

--- a/packages/zenrouter_core/pubspec.yaml
+++ b/packages/zenrouter_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: zenrouter_core
 description: >-
   The core routing engine and unified interfaces for the ZenRouter navigation system.
   Contains common models, types, and logic used across the zenrouter ecosystem.
-version: 2.1.0
+version: 2.2.0
 
 repository: https://github.com/definev/zenrouter
 homepage: https://github.com/definev/zenrouter/tree/main/packages/zenrouter_core

--- a/packages/zenrouter_core/test/internal/reactive_test.dart
+++ b/packages/zenrouter_core/test/internal/reactive_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zenrouter_core/src/internal/reactive.dart';
+
+void main() {
+  group('ListenableMixin.merge', () {
+    test('ignores null entries', () {
+      final a = _RecordingListenable('a');
+      final merged = ListenableMixin.merge([null, a, null]);
+
+      var notified = 0;
+      merged.addListener(() => notified++);
+      a.notify();
+      expect(notified, 1);
+    });
+
+    test('notifies when any child notifies', () {
+      final a = _RecordingListenable('a');
+      final b = _RecordingListenable('b');
+      final merged = ListenableMixin.merge([a, b]);
+
+      var notified = 0;
+      merged.addListener(() => notified++);
+
+      a.notify();
+      expect(notified, 1);
+      b.notify();
+      expect(notified, 2);
+    });
+
+    test('addListener registers on every child', () {
+      final a = _RecordingListenable('a');
+      final b = _RecordingListenable('b');
+      final merged = ListenableMixin.merge([a, b]);
+
+      void listener() {}
+      merged.addListener(listener);
+
+      expect(a.listeners, contains(listener));
+      expect(b.listeners, contains(listener));
+    });
+
+    test('removeListener unregisters from every child', () {
+      final a = _RecordingListenable('a');
+      final b = _RecordingListenable('b');
+      final merged = ListenableMixin.merge([a, b]);
+
+      void listener() {}
+      merged.addListener(listener);
+      merged.removeListener(listener);
+
+      expect(a.listeners, isEmpty);
+      expect(b.listeners, isEmpty);
+    });
+
+    test('empty merge accepts listeners without notifying', () {
+      final merged = ListenableMixin.merge(const <ListenableMixin?>[]);
+      var notified = 0;
+      merged.addListener(() => notified++);
+      merged.removeListener(() => notified++);
+      expect(notified, 0);
+    });
+
+    test('all-null merge behaves like empty', () {
+      final merged = ListenableMixin.merge([null, null]);
+      var notified = 0;
+      void listener() => notified++;
+      merged.addListener(listener);
+      merged.removeListener(listener);
+      expect(notified, 0);
+    });
+
+    test('toString lists children', () {
+      final a = _RecordingListenable('a');
+      final b = _RecordingListenable('b');
+      final merged = ListenableMixin.merge([a, b]);
+
+      expect(
+        merged.toString(),
+        'ListenableMixin.merge([_RecordingListenable(a), _RecordingListenable(b)])',
+      );
+    });
+
+    test('toString for empty merge', () {
+      expect(
+        ListenableMixin.merge(const <ListenableMixin?>[]).toString(),
+        'ListenableMixin.merge([])',
+      );
+    });
+
+    test('snapshot is fixed after creation', () {
+      final a = _RecordingListenable('a');
+      final children = <ListenableMixin?>[a];
+      final merged = ListenableMixin.merge(children);
+
+      // Mutating the source iterable after merge must not affect listeners.
+      children.add(_RecordingListenable('late'));
+
+      var notified = 0;
+      merged.addListener(() => notified++);
+      a.notify();
+      expect(notified, 1);
+      expect(a.listeners, hasLength(1));
+    });
+  });
+
+  group('ListenableObject', () {
+    test('dispose is callable and mustCallSuper-safe', () {
+      final object = _TestListenableObject();
+      expect(object.disposed, isFalse);
+      object.dispose();
+      expect(object.disposed, isTrue);
+    });
+
+    test('implements ListenableMixin', () {
+      final object = _TestListenableObject();
+      expect(object, isA<ListenableMixin>());
+
+      var notified = 0;
+      object.addListener(() => notified++);
+      object.notifyListeners();
+      expect(notified, 1);
+
+      object.removeListener(object.listeners.single);
+      object.notifyListeners();
+      expect(notified, 1);
+    });
+  });
+}
+
+class _RecordingListenable implements ListenableMixin {
+  _RecordingListenable(this.label);
+
+  final String label;
+  final listeners = <VoidCallback>[];
+
+  @override
+  void addListener(VoidCallback listener) => listeners.add(listener);
+
+  @override
+  void removeListener(VoidCallback listener) => listeners.remove(listener);
+
+  void notify() {
+    for (final listener in List<VoidCallback>.of(listeners)) {
+      listener();
+    }
+  }
+
+  @override
+  String toString() => '_RecordingListenable($label)';
+}
+
+class _TestListenableObject with ListenableObject {
+  final listeners = <VoidCallback>[];
+  bool disposed = false;
+
+  @override
+  void addListener(VoidCallback listener) => listeners.add(listener);
+
+  @override
+  void removeListener(VoidCallback listener) => listeners.remove(listener);
+
+  @override
+  void notifyListeners() {
+    for (final listener in List<VoidCallback>.of(listeners)) {
+      listener();
+    }
+  }
+
+  @override
+  void dispose() {
+    disposed = true;
+    super.dispose();
+  }
+}

--- a/packages/zenrouter_core/test/mixin/guard_rule_test.dart
+++ b/packages/zenrouter_core/test/mixin/guard_rule_test.dart
@@ -22,9 +22,9 @@ class RuleGuardedRoute extends TestRoute with RouteGuardRule<TestRoute> {
 
 void main() {
   group('RouteGuardRule', () {
-    test('popGuard defaults to true', () {
+    test('popGuard defaults to true', () async {
       final route = RuleGuardedRoute('1', rules: []);
-      expect(route.popGuard(), isTrue);
+      expect(await route.popGuard(), isTrue);
     });
 
     test('implements RouteGuard', () {
@@ -79,6 +79,54 @@ void main() {
       b.notify();
       expect(notified, 2);
     });
+
+    test('popGuard runs guardRule without coordinator', () async {
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _NonCoordinatorBlockRule()],
+      );
+      expect(await route.popGuard(), isFalse);
+    });
+
+    test('default guardRule is null so chain continues', () async {
+      final rule = const _FixedCanPopRule(true);
+      expect(await rule.guardRule(TestRoute('1')), isNull);
+    });
+
+    test('With methods default to non-With counterparts', () async {
+      final route = TestRoute('1');
+      final rule = const _NonCoordinatorBlockRule();
+
+      // canPopRuleWith / canPopListenableRuleWith / guardRuleWith
+      // fall back when not overridden.
+      expect(rule.canPopRule(route), isTrue);
+      expect(rule.canPopListenableRule(route), isNull);
+      expect(await rule.guardRule(route), isFalse);
+    });
+
+    test('guardRuleWith can override without changing guardRule', () async {
+      final route = TestRoute('1');
+      final rule = const _CoordinatorOnlyAllowRule();
+
+      expect(await rule.guardRule(route), isNull);
+      // Call With via a typed cast to avoid standing up a full coordinator.
+      expect(
+        await rule.guardRuleWith(_UnusedCoordinator(), route),
+        isTrue,
+      );
+    });
+
+    test('canPopRuleWith can differ from canPopRule', () {
+      final route = TestRoute('1');
+      final rule = const _CoordinatorCanPopRule();
+
+      expect(rule.canPopRule(route), isTrue);
+      expect(rule.canPopRuleWith(_UnusedCoordinator(), route), isFalse);
+
+      final guarded = RuleGuardedRoute('1', rules: [rule]);
+      expect(guarded.canPop, isTrue);
+      expect(guarded.canPopWith(_UnusedCoordinator()), isFalse);
+    });
   });
 }
 
@@ -98,19 +146,19 @@ class _TestListenable implements ListenableMixin {
   }
 }
 
+/// Minimal stand-in so typed `CoordinatorCore` parameters compile in tests.
+class _UnusedCoordinator implements CoordinatorCore<RouteUri> {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 class _FixedCanPopRule extends GuardRule<TestRoute> {
   const _FixedCanPopRule(this._canPop);
 
   final bool _canPop;
 
   @override
-  bool canPop(covariant TestRoute route) => _canPop;
-
-  @override
-  FutureOr<bool?> guard(
-    covariant CoordinatorCore coordinator,
-    covariant TestRoute route,
-  ) => null;
+  bool canPopRule(covariant TestRoute route) => _canPop;
 }
 
 class _ListenableRule extends GuardRule<TestRoute> {
@@ -119,11 +167,33 @@ class _ListenableRule extends GuardRule<TestRoute> {
   final ListenableMixin _listenable;
 
   @override
-  ListenableMixin? canPopListenable(covariant TestRoute route) => _listenable;
+  ListenableMixin? canPopListenableRule(covariant TestRoute route) =>
+      _listenable;
+}
+
+class _CoordinatorCanPopRule extends GuardRule<TestRoute> {
+  const _CoordinatorCanPopRule();
 
   @override
-  FutureOr<bool?> guard(
+  bool canPopRuleWith(
     covariant CoordinatorCore coordinator,
     covariant TestRoute route,
-  ) => null;
+  ) => false;
+}
+
+class _NonCoordinatorBlockRule extends GuardRule<TestRoute> {
+  const _NonCoordinatorBlockRule();
+
+  @override
+  FutureOr<bool?> guardRule(covariant TestRoute route) => false;
+}
+
+class _CoordinatorOnlyAllowRule extends GuardRule<TestRoute> {
+  const _CoordinatorOnlyAllowRule();
+
+  @override
+  FutureOr<bool?> guardRuleWith(
+    covariant CoordinatorCore coordinator,
+    covariant TestRoute route,
+  ) => true;
 }

--- a/packages/zenrouter_core/test/mixin/guard_rule_test.dart
+++ b/packages/zenrouter_core/test/mixin/guard_rule_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_use_of_protected_member
+
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -9,6 +11,9 @@ class TestRoute extends RouteTarget {
 
   @override
   List<Object?> get props => [id];
+
+  @override
+  String toString() => 'TestRoute($id)';
 }
 
 class RuleGuardedRoute extends TestRoute with RouteGuardRule<TestRoute> {
@@ -21,15 +26,85 @@ class RuleGuardedRoute extends TestRoute with RouteGuardRule<TestRoute> {
 }
 
 void main() {
-  group('RouteGuardRule', () {
-    test('popGuard defaults to true', () async {
-      final route = RuleGuardedRoute('1', rules: []);
-      expect(await route.popGuard(), isTrue);
+  group('GuardRule defaults', () {
+    const rule = _DefaultGuardRule();
+    final route = TestRoute('1');
+    final coordinator = _UnusedCoordinator();
+
+    test('canPopRule defaults to true', () {
+      expect(rule.canPopRule(route), isTrue);
     });
 
+    test('canPopListenableRule defaults to null', () {
+      expect(rule.canPopListenableRule(route), isNull);
+    });
+
+    test('guardRule defaults to null', () async {
+      expect(await rule.guardRule(route), isNull);
+    });
+
+    test('canPopRuleWith defaults to canPopRule', () {
+      expect(rule.canPopRuleWith(coordinator, route), isTrue);
+    });
+
+    test('canPopListenableRuleWith defaults to canPopListenableRule', () {
+      expect(rule.canPopListenableRuleWith(coordinator, route), isNull);
+    });
+
+    test('guardRuleWith defaults to guardRule', () async {
+      expect(await rule.guardRuleWith(coordinator, route), isNull);
+    });
+
+    test('const constructor is usable', () {
+      expect(const _DefaultGuardRule(), isA<GuardRule<TestRoute>>());
+    });
+  });
+
+  group('GuardRule With overrides', () {
+    test('canPopRuleWith can differ from canPopRule', () {
+      final route = TestRoute('1');
+      const rule = _CoordinatorCanPopRule();
+
+      expect(rule.canPopRule(route), isTrue);
+      expect(rule.canPopRuleWith(_UnusedCoordinator(), route), isFalse);
+    });
+
+    test('canPopListenableRuleWith can differ from canPopListenableRule', () {
+      final route = TestRoute('1');
+      final withOnly = _TestListenable();
+      final rule = _CoordinatorListenableRule(withOnly);
+
+      expect(rule.canPopListenableRule(route), isNull);
+      expect(
+        rule.canPopListenableRuleWith(_UnusedCoordinator(), route),
+        same(withOnly),
+      );
+    });
+
+    test('guardRuleWith can override without changing guardRule', () async {
+      final route = TestRoute('1');
+      const rule = _CoordinatorOnlyAllowRule();
+
+      expect(await rule.guardRule(route), isNull);
+      expect(await rule.guardRuleWith(_UnusedCoordinator(), route), isTrue);
+    });
+
+    test('guardRuleWith defaults through to overridden guardRule', () async {
+      final route = TestRoute('1');
+      const rule = _NonCoordinatorBlockRule();
+
+      expect(await rule.guardRule(route), isFalse);
+      expect(await rule.guardRuleWith(_UnusedCoordinator(), route), isFalse);
+    });
+  });
+
+  group('RouteGuardRule.canPop / canPopWith', () {
     test('implements RouteGuard', () {
-      final route = RuleGuardedRoute('1', rules: []);
-      expect(route, isA<RouteGuard>());
+      expect(RuleGuardedRoute('1', rules: []), isA<RouteGuard>());
+    });
+
+    test('canPop is true for empty rules', () {
+      expect(RuleGuardedRoute('1', rules: []).canPop, isTrue);
     });
 
     test('canPop is true when every rule allows', () {
@@ -48,39 +123,127 @@ void main() {
       expect(route.canPop, isFalse);
     });
 
-    test('canPopListenable is null when no rules expose one', () {
+    test('canPopWith uses canPopRuleWith', () {
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _CoordinatorCanPopRule()],
+      );
+      expect(route.canPop, isTrue);
+      expect(route.canPopWith(_UnusedCoordinator()), isFalse);
+    });
+  });
+
+  group('RouteGuardRule.canPopListenable / canPopListenableWith', () {
+    test('null when no rules expose a listenable', () {
       final route = RuleGuardedRoute(
         '1',
         rules: [const _FixedCanPopRule(true)],
       );
       expect(route.canPopListenable, isNull);
+      expect(route.canPopListenableWith(_UnusedCoordinator()), isNull);
     });
 
-    test('canPopListenable returns single listenable', () {
+    test('returns single listenable unchanged', () {
       final notifier = _TestListenable();
       final route = RuleGuardedRoute('1', rules: [_ListenableRule(notifier)]);
       expect(route.canPopListenable, same(notifier));
     });
 
-    test('canPopListenable merges multiple listenables', () {
+    test('skips rules that return null listenable', () {
+      final notifier = _TestListenable();
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [
+          const _FixedCanPopRule(true),
+          _ListenableRule(notifier),
+          const _FixedCanPopRule(true),
+        ],
+      );
+      expect(route.canPopListenable, same(notifier));
+    });
+
+    test('merges multiple listenables', () {
       final a = _TestListenable();
       final b = _TestListenable();
       final route = RuleGuardedRoute(
         '1',
         rules: [_ListenableRule(a), _ListenableRule(b)],
       );
-      expect(route.canPopListenable, isA<ListenableMixin>());
-      expect(route.canPopListenable, isNot(same(a)));
-      expect(route.canPopListenable, isNot(same(b)));
+      final merged = route.canPopListenable!;
+      expect(merged, isNot(same(a)));
+      expect(merged, isNot(same(b)));
 
       var notified = 0;
-      route.canPopListenable!.addListener(() => notified++);
+      merged.addListener(() => notified++);
       a.notify();
       b.notify();
       expect(notified, 2);
     });
 
-    test('popGuard runs guardRule without coordinator', () async {
+    test('merged listenable removeListener stops notifications', () {
+      final a = _TestListenable();
+      final b = _TestListenable();
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [_ListenableRule(a), _ListenableRule(b)],
+      );
+      final merged = route.canPopListenable!;
+
+      var notified = 0;
+      void listener() => notified++;
+      merged.addListener(listener);
+      a.notify();
+      expect(notified, 1);
+
+      merged.removeListener(listener);
+      a.notify();
+      b.notify();
+      expect(notified, 1);
+    });
+
+    test('canPopListenableWith uses canPopListenableRuleWith', () {
+      final withOnly = _TestListenable();
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [_CoordinatorListenableRule(withOnly)],
+      );
+      expect(route.canPopListenable, isNull);
+      expect(route.canPopListenableWith(_UnusedCoordinator()), same(withOnly));
+    });
+
+    test('canPopListenableWith merges multiple With listenables', () {
+      final a = _TestListenable();
+      final b = _TestListenable();
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [_CoordinatorListenableRule(a), _CoordinatorListenableRule(b)],
+      );
+      final merged = route.canPopListenableWith(_UnusedCoordinator())!;
+      expect(merged, isNot(same(a)));
+      expect(merged, isNot(same(b)));
+
+      var notified = 0;
+      merged.addListener(() => notified++);
+      a.notify();
+      b.notify();
+      expect(notified, 2);
+    });
+  });
+
+  group('RouteGuardRule.popGuard chain', () {
+    test('empty rules allow pop', () async {
+      expect(await RuleGuardedRoute('1', rules: []).popGuard(), isTrue);
+    });
+
+    test('all-null rules allow pop', () async {
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _ContinueRule(), const _ContinueRule()],
+      );
+      expect(await route.popGuard(), isTrue);
+    });
+
+    test('false blocks pop', () async {
       final route = RuleGuardedRoute(
         '1',
         rules: [const _NonCoordinatorBlockRule()],
@@ -88,47 +251,145 @@ void main() {
       expect(await route.popGuard(), isFalse);
     });
 
-    test('default guardRule is null so chain continues', () async {
-      final rule = const _FixedCanPopRule(true);
-      expect(await rule.guardRule(TestRoute('1')), isNull);
+    test('true allows pop', () async {
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _NonCoordinatorAllowRule()],
+      );
+      expect(await route.popGuard(), isTrue);
     });
 
-    test('With methods default to non-With counterparts', () async {
-      final route = TestRoute('1');
-      final rule = const _NonCoordinatorBlockRule();
-
-      // canPopRuleWith / canPopListenableRuleWith / guardRuleWith
-      // fall back when not overridden.
-      expect(rule.canPopRule(route), isTrue);
-      expect(rule.canPopListenableRule(route), isNull);
-      expect(await rule.guardRule(route), isFalse);
+    test('null continues to next rule which can block', () async {
+      final second = _CountingRule(false);
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _ContinueRule(), second],
+      );
+      expect(await route.popGuard(), isFalse);
+      expect(second.callCount, 1);
     });
 
-    test('guardRuleWith can override without changing guardRule', () async {
-      final route = TestRoute('1');
-      final rule = const _CoordinatorOnlyAllowRule();
+    test('true short-circuits later rules', () async {
+      final later = _CountingRule(false);
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _NonCoordinatorAllowRule(), later],
+      );
+      expect(await route.popGuard(), isTrue);
+      expect(later.callCount, 0);
+    });
 
-      expect(await rule.guardRule(route), isNull);
-      // Call With via a typed cast to avoid standing up a full coordinator.
+    test('false short-circuits later rules', () async {
+      final later = _CountingRule(true);
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _NonCoordinatorBlockRule(), later],
+      );
+      expect(await route.popGuard(), isFalse);
+      expect(later.callCount, 0);
+    });
+
+    test('async guardRule is awaited', () async {
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _AsyncRule(false, delay: Duration(milliseconds: 5))],
+      );
+      expect(await route.popGuard(), isFalse);
+    });
+  });
+
+  group('RouteGuardRule.popGuardWith chain', () {
+    test('asserts when stackPath is null', () {
+      final route = RuleGuardedRoute('1', rules: [const _ContinueRule()]);
       expect(
-        await rule.guardRuleWith(_UnusedCoordinator(), route),
-        isTrue,
+        () => route.popGuardWith(_UnusedCoordinator()),
+        throwsA(isA<AssertionError>()),
       );
     });
 
-    test('canPopRuleWith can differ from canPopRule', () {
-      final route = TestRoute('1');
-      final rule = const _CoordinatorCanPopRule();
+    test('asserts when coordinator mismatches', () {
+      final expected = _UnusedCoordinator();
+      final other = _UnusedCoordinator();
+      final route = RuleGuardedRoute('1', rules: [const _ContinueRule()]);
+      route.bindStackPath(_MockStackPath(coordinator: expected));
 
-      expect(rule.canPopRule(route), isTrue);
-      expect(rule.canPopRuleWith(_UnusedCoordinator(), route), isFalse);
+      expect(() => route.popGuardWith(other), throwsA(isA<AssertionError>()));
+    });
 
-      final guarded = RuleGuardedRoute('1', rules: [rule]);
-      expect(guarded.canPop, isTrue);
-      expect(guarded.canPopWith(_UnusedCoordinator()), isFalse);
+    test('empty rules allow pop when coordinator matches', () async {
+      final coordinator = _UnusedCoordinator();
+      final route = RuleGuardedRoute('1', rules: []);
+      route.bindStackPath(_MockStackPath(coordinator: coordinator));
+
+      expect(await route.popGuardWith(coordinator), isTrue);
+    });
+
+    test('all-null With rules allow pop', () async {
+      final coordinator = _UnusedCoordinator();
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _ContinueRule(), const _ContinueRule()],
+      );
+      route.bindStackPath(_MockStackPath(coordinator: coordinator));
+
+      expect(await route.popGuardWith(coordinator), isTrue);
+    });
+
+    test('false from guardRuleWith blocks pop', () async {
+      final coordinator = _UnusedCoordinator();
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _CoordinatorOnlyBlockRule()],
+      );
+      route.bindStackPath(_MockStackPath(coordinator: coordinator));
+
+      expect(await route.popGuardWith(coordinator), isFalse);
+      // Non-coordinator path still has no opinion.
+      expect(await route.popGuard(), isTrue);
+    });
+
+    test('true from guardRuleWith allows and short-circuits', () async {
+      final coordinator = _UnusedCoordinator();
+      final later = _CountingWithRule(false);
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _CoordinatorOnlyAllowRule(), later],
+      );
+      route.bindStackPath(_MockStackPath(coordinator: coordinator));
+
+      expect(await route.popGuardWith(coordinator), isTrue);
+      expect(later.callCount, 0);
+    });
+
+    test('null continues to next With rule', () async {
+      final coordinator = _UnusedCoordinator();
+      final second = _CountingWithRule(false);
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _ContinueRule(), second],
+      );
+      route.bindStackPath(_MockStackPath(coordinator: coordinator));
+
+      expect(await route.popGuardWith(coordinator), isFalse);
+      expect(second.callCount, 1);
+    });
+
+    test('async guardRuleWith is awaited', () async {
+      final coordinator = _UnusedCoordinator();
+      final route = RuleGuardedRoute(
+        '1',
+        rules: [const _AsyncWithRule(true, delay: Duration(milliseconds: 5))],
+      );
+      route.bindStackPath(_MockStackPath(coordinator: coordinator));
+
+      expect(await route.popGuardWith(coordinator), isTrue);
     });
   });
 }
+
+// =============================================================================
+// Fakes
+// =============================================================================
 
 class _TestListenable implements ListenableMixin {
   final _listeners = <void Function()>[];
@@ -144,12 +405,70 @@ class _TestListenable implements ListenableMixin {
       listener();
     }
   }
+
+  @override
+  String toString() => '_TestListenable';
 }
 
-/// Minimal stand-in so typed `CoordinatorCore` parameters compile in tests.
 class _UnusedCoordinator implements CoordinatorCore<RouteUri> {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _MockStackPath implements StackPath<TestRoute> {
+  _MockStackPath({this.coordinator});
+
+  @override
+  final CoordinatorCore? coordinator;
+
+  @override
+  TestRoute? get activeRoute => null;
+
+  @override
+  PathKey get pathKey => const PathKey('mock');
+
+  @override
+  List<TestRoute> get stack => const [];
+
+  @override
+  String? get debugLabel => null;
+
+  @override
+  CoordinatorCore? get proxyCoordinator => null;
+
+  @override
+  void addListener(VoidCallback listener) {}
+
+  @override
+  void removeListener(VoidCallback listener) {}
+
+  @override
+  void notifyListeners() {}
+
+  @override
+  void clear() {}
+
+  @override
+  void bindStack(List<TestRoute> stack) {}
+
+  @override
+  void reset() {}
+
+  @override
+  Future<void> activateRoute(TestRoute route) async {}
+
+  @override
+  void dispose() {}
+}
+
+typedef VoidCallback = void Function();
+
+// =============================================================================
+// Rules
+// =============================================================================
+
+class _DefaultGuardRule extends GuardRule<TestRoute> {
+  const _DefaultGuardRule();
 }
 
 class _FixedCanPopRule extends GuardRule<TestRoute> {
@@ -181,11 +500,30 @@ class _CoordinatorCanPopRule extends GuardRule<TestRoute> {
   ) => false;
 }
 
+class _CoordinatorListenableRule extends GuardRule<TestRoute> {
+  _CoordinatorListenableRule(this._listenable);
+
+  final ListenableMixin _listenable;
+
+  @override
+  ListenableMixin? canPopListenableRuleWith(
+    covariant CoordinatorCore coordinator,
+    covariant TestRoute route,
+  ) => _listenable;
+}
+
 class _NonCoordinatorBlockRule extends GuardRule<TestRoute> {
   const _NonCoordinatorBlockRule();
 
   @override
   FutureOr<bool?> guardRule(covariant TestRoute route) => false;
+}
+
+class _NonCoordinatorAllowRule extends GuardRule<TestRoute> {
+  const _NonCoordinatorAllowRule();
+
+  @override
+  FutureOr<bool?> guardRule(covariant TestRoute route) => true;
 }
 
 class _CoordinatorOnlyAllowRule extends GuardRule<TestRoute> {
@@ -196,4 +534,79 @@ class _CoordinatorOnlyAllowRule extends GuardRule<TestRoute> {
     covariant CoordinatorCore coordinator,
     covariant TestRoute route,
   ) => true;
+}
+
+class _CoordinatorOnlyBlockRule extends GuardRule<TestRoute> {
+  const _CoordinatorOnlyBlockRule();
+
+  @override
+  FutureOr<bool?> guardRuleWith(
+    covariant CoordinatorCore coordinator,
+    covariant TestRoute route,
+  ) => false;
+}
+
+class _ContinueRule extends GuardRule<TestRoute> {
+  const _ContinueRule();
+
+  @override
+  FutureOr<bool?> guardRule(covariant TestRoute route) => null;
+}
+
+class _CountingRule extends GuardRule<TestRoute> {
+  _CountingRule(this.result);
+
+  final bool? result;
+  int callCount = 0;
+
+  @override
+  FutureOr<bool?> guardRule(covariant TestRoute route) {
+    callCount++;
+    return result;
+  }
+}
+
+class _CountingWithRule extends GuardRule<TestRoute> {
+  _CountingWithRule(this.result);
+
+  final bool? result;
+  int callCount = 0;
+
+  @override
+  FutureOr<bool?> guardRuleWith(
+    covariant CoordinatorCore coordinator,
+    covariant TestRoute route,
+  ) {
+    callCount++;
+    return result;
+  }
+}
+
+class _AsyncRule extends GuardRule<TestRoute> {
+  const _AsyncRule(this.result, {required this.delay});
+
+  final bool? result;
+  final Duration delay;
+
+  @override
+  Future<bool?> guardRule(covariant TestRoute route) async {
+    await Future<void>.delayed(delay);
+    return result;
+  }
+}
+
+class _AsyncWithRule extends GuardRule<TestRoute> {
+  const _AsyncWithRule(this.result, {required this.delay});
+
+  final bool? result;
+  final Duration delay;
+
+  @override
+  Future<bool?> guardRuleWith(
+    covariant CoordinatorCore coordinator,
+    covariant TestRoute route,
+  ) async {
+    await Future<void>.delayed(delay);
+    return result;
+  }
 }

--- a/skills/zenrouter/ADVANCED.md
+++ b/skills/zenrouter/ADVANCED.md
@@ -257,20 +257,24 @@ class ShopIndexRoute extends AppRoute with RouteRedirectRule<AppRoute> {
 
 Composable pop guards applied via `RouteGuardRule<T>` mixin on a route.
 
+Prefer **route-only** methods when no coordinator is needed. Override the
+`With` variants when dialogs or shared app state require a coordinator
+(defaults delegate to the non-`With` methods).
+
 ### Writing a rule
 
 ```dart
 class UnsavedChangesRule extends GuardRule<AppRoute> {
   @override
-  bool canPop(AppRoute route) =>
+  bool canPopRule(AppRoute route) =>
       route is! EditableRoute || !route.hasUnsavedChanges;
 
   @override
-  ListenableMixin? canPopListenable(AppRoute route) =>
+  ListenableMixin? canPopListenableRule(AppRoute route) =>
       route is EditableRoute ? route.dirty.toListenableMixin() : null;
 
   @override
-  Future<bool?> guard(
+  Future<bool?> guardRuleWith(
     covariant AppCoordinator coordinator,
     AppRoute route,
   ) async {
@@ -282,18 +286,18 @@ class UnsavedChangesRule extends GuardRule<AppRoute> {
 }
 ```
 
-| `bool?` (async `guard`) | Meaning |
-|:------------------------|:--------|
+| `bool?` (`guardRule` / `guardRuleWith`) | Meaning |
+|:----------------------------------------|:--------|
 | `null` | Pass to next rule |
 | `true` | Allow pop; stops chain |
 | `false` | Block pop; stops chain |
 
-| Sync `canPop` | Meaning |
-|:--------------|:--------|
+| Sync `canPopRule` | Meaning |
+|:------------------|:--------|
 | `true` (default) | This rule does not force intercept |
 | `false` | Force `PopScope` intercept |
 
-Rules are evaluated in list order; first non-`null` `guard` result wins. If every rule returns `null`, the pop is allowed. `RouteGuardRule.canPop` is `true` only when every rule's `canPop` is `true`.
+Rules are evaluated in list order; first non-`null` result wins. If every rule returns `null`, the pop is allowed. `RouteGuardRule.canPop` is `true` only when every rule's `canPopRule` is `true`.
 
 ### Applying rules to a route
 

--- a/skills/zenrouter/MIXIN.md
+++ b/skills/zenrouter/MIXIN.md
@@ -92,7 +92,9 @@ Intercepts pop operations so you can block or confirm navigation away.
 ```dart
 mixin RouteGuard on RouteTarget {
   bool get canPop;                                    // PopScope.canPop (default false)
+  bool canPopWith(CoordinatorCore coordinator);       // defaults to canPop
   ListenableMixin? get canPopListenable;              // reactive canPop invalidation
+  ListenableMixin? canPopListenableWith(CoordinatorCore coordinator);
   FutureOr<bool> popGuard();                              // return false to block pop
   FutureOr<bool> popGuardWith(CoordinatorCore coordinator); // same, with coordinator access
 }
@@ -100,8 +102,9 @@ mixin RouteGuard on RouteTarget {
 
 - `canPop: true` → platform pops freely (no `popGuard` for that gesture).
 - `canPop: false` → intercept, then `popGuard` decides.
-- Programmatic `pop` always consults `popGuard`.
+- Programmatic `pop` always consults `popGuard` / `popGuardWith`.
 - Set `canPopListenable` (e.g. `dirty.toListenableMixin()` on a Flutter `ValueNotifier` / `ChangeNotifier`) so `PopScope` updates when state changes.
+- Use `*With` when the hint/listenable depends on coordinator state.
 
 **Example — reactive unsaved changes:**
 
@@ -159,10 +162,11 @@ Sync [canPop](./MIXIN.md#routeguard) composition:
 
 | API | Meaning |
 |:----|:--------|
-| `GuardRule.canPop(route)` | `false` forces intercept; default `true` |
+| `GuardRule.canPopRule(route)` | `false` forces intercept; default `true` |
+| `GuardRule.canPopRuleWith(c, route)` | Coordinator-aware; defaults to `canPopRule` |
 | `RouteGuardRule.canPop` | `true` only if every rule returns `true` |
-| `GuardRule.canPopListenable(route)` | Optional `ListenableMixin` |
-| `RouteGuardRule.canPopListenable` | Single listenable, or `ListenableMixin.merge` |
+| `GuardRule.canPopListenableRule(route)` | Optional `ListenableMixin` |
+| `GuardRule.guardRule(route)` / `guardRuleWith(c, route)` | Chain decision; default `null` |
 
 ---
 


### PR DESCRIPTION
## Summary

Breaks the `GuardRule` contract from `zenrouter_core` **2.1.0** / `zenrouter` **2.2.0** so pop-guard rules can run **without a `Coordinator`**, mirroring `RouteGuard.popGuard` / `popGuardWith`.

| Package | Version |
|---------|---------|
| `zenrouter_core` | `2.1.0` → **`2.2.0`** |
| `zenrouter` | `2.2.0` → **`2.3.0`** |

## Why this breaking change is required

### 1. The old `guard(coordinator, route)` forced a coordinator

`GuardRule.guard` required a `CoordinatorCore` on every call. That blocked legitimate headless / non-Flutter / unit-test / imperative-stack use cases where:

- leave checks only need route-local state (`dirty`, `uploading`, flags)
- there is no coordinator wired (or asserting `stackPath.coordinator` is wrong)
- rules should be unit-tested with a plain route, no navigator / coordinator stub

Keeping a single coordinator-required method meant either lying with a fake coordinator or refusing to support those paths.

### 2. `RouteGuard` already had the dual API — rules did not

`RouteGuard` exposes:

- `popGuard()` — no coordinator
- `popGuardWith(coordinator)` — coordinator-aware

But `RouteGuardRule` only implemented the chain via `guard(coordinator, …)`, and `popGuard()` was effectively a stub (`true`). That made the mixin inconsistent: routes looked coordinator-optional at the `RouteGuard` layer, then forced a coordinator again at the rule layer.

### 3. Rename (not overload) keeps overrides unambiguous

Dart cannot cleanly express “override route-only vs coordinator-aware” on the same name with different arity when defaults must chain (`With` → non-`With`). Renaming to `guardRule` / `guardRuleWith` (and `canPopRule` / `canPopRuleWith`, …) makes which contract you implement explicit and avoids accidental infinite recursion / wrong default chains.

A soft-deprecation shim was considered, but the API shipped only in **2.1.0 / 2.2.0** and the method names (`guard` vs `canPop` on `RouteGuard`) were already confusing — a clean break with a migration table is cheaper than carrying aliases.

## Migration

| Removed (2.1.0) | Replacement |
|-----------------|-------------|
| `canPop(route)` | `canPopRule(route)` / `canPopRuleWith(c, route)` |
| `canPopListenable(route)` | `canPopListenableRule(route)` / `canPopListenableRuleWith(c, route)` |
| `guard(c, route)` | `guardRule(route)` / `guardRuleWith(c, route)` |

```dart
// Before
class UnsavedChangesRule extends GuardRule<AppRoute> {
  @override
  bool canPop(AppRoute route) => !route.hasUnsavedChanges;

  @override
  FutureOr<bool?> guard(Coordinator c, AppRoute route) async =>
      showDiscardDialog(c.navigator.context);
}

// After — dialogs still use With; sync hints stay route-only
class UnsavedChangesRule extends GuardRule<AppRoute> {
  @override
  bool canPopRule(AppRoute route) => !route.hasUnsavedChanges;

  @override
  FutureOr<bool?> guardRuleWith(Coordinator c, AppRoute route) async =>
      showDiscardDialog(c.navigator.context);
}
```

Each `*With` defaults to its non-`With` counterpart. `guardRule` defaults to `null` (continue chain).

## Also in this PR

- `RouteGuard.canPopWith` / `canPopListenableWith`
- `NavigationStack` prefers `*With` when a coordinator is present
- `RouteGuardRule.popGuard` runs the real `guardRule` chain
- `CoordinatorCore.tryPop` returns `null` when no eligible path (matches docs: true / false / null)
- Docs, example, skills, CHANGELOGs updated

## Test plan

- [ ] `cd packages/zenrouter_core && flutter test test/mixin/guard_rule_test.dart test/mixin/guard_test.dart`
- [ ] `cd packages/zenrouter && flutter test test/mixin/guard_rule_test.dart test/mixin/guard_test.dart`
- [ ] Confirm a rule that only overrides `guardRule` works via `popGuard()` (no coordinator)
- [ ] Confirm a rule that only overrides `guardRuleWith` still works via `coordinator.pop()`
- [ ] `flutter run -t lib/main_guard_rules.dart` — dirty / upload dialogs still intercept correctly
- [ ] Grep consumer code for `.guard(`, `canPop(`, `canPopListenable(` on `GuardRule` subclasses and rename


Made with [Cursor](https://cursor.com)